### PR TITLE
Add `recap search`

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -30,6 +30,11 @@ requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7
 summary = "Cross-platform colored terminal text."
 
 [[package]]
+name = "commonmark"
+version = "0.9.1"
+summary = "Python parser for the CommonMark Markdown spec"
+
+[[package]]
 name = "dynaconf"
 version = "3.1.11"
 requires_python = ">=3.7"
@@ -115,6 +120,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.13.0"
+requires_python = ">=3.6"
+summary = "Pygments is a syntax highlighting package written in Python."
+
+[[package]]
+name = "pyjq"
+version = "2.6.0"
+summary = "Binding for jq JSON processor."
+
+[[package]]
 name = "python-dotenv"
 version = "0.21.0"
 requires_python = ">=3.7"
@@ -139,6 +155,16 @@ summary = "Validating URI References per RFC 3986"
 dependencies = [
     "idna",
     "rfc3986==1.5.0",
+]
+
+[[package]]
+name = "rich"
+version = "12.6.0"
+requires_python = ">=3.6.3,<4.0.0"
+summary = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+dependencies = [
+    "commonmark<0.10.0,>=0.9.0",
+    "pygments<3.0.0,>=2.6.0",
 ]
 
 [[package]]
@@ -230,7 +256,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:547a365bc3ee8e424d3d639bd36e12f5d4baf608a1021e7d055a35b9b2833873"
+content_hash = "sha256:b18a02087d809a43d22ca292504dbd8cf6934f1c9c5406f10b247ea87122795a"
 
 [metadata.files]
 "anyio 3.6.2" = [
@@ -248,6 +274,10 @@ content_hash = "sha256:547a365bc3ee8e424d3d639bd36e12f5d4baf608a1021e7d055a35b9b
 "colorama 0.4.6" = [
     {url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+]
+"commonmark 0.9.1" = [
+    {url = "https://files.pythonhosted.org/packages/60/48/a60f593447e8f0894ebb7f6e6c1f25dafc5e89c5879fdc9360ae93ff83f0/commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
+    {url = "https://files.pythonhosted.org/packages/b1/92/dfd892312d822f36c55366118b95d914e5f16de11044a27cf10a7d71bbbf/commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
 ]
 "dynaconf 3.1.11" = [
     {url = "https://files.pythonhosted.org/packages/54/6f/09c3ca2943314e0cae5cb2eeca1b77f5968855e13d6fdaae32c8e055eb7c/dynaconf-3.1.11.tar.gz", hash = "sha256:d9cfb50fd4a71a543fd23845d4f585b620b6ff6d9d3cc1825c614f7b2097cb39"},
@@ -435,6 +465,14 @@ content_hash = "sha256:547a365bc3ee8e424d3d639bd36e12f5d4baf608a1021e7d055a35b9b
     {url = "https://files.pythonhosted.org/packages/fe/5b/6f77e6ebc93e5e3c7fd480e1b171a6547407eba901a56a65d2745df24144/pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
     {url = "https://files.pythonhosted.org/packages/fe/fd/8f7f8271d526378c927babd1229501e576760cef9a509909a3415eec3c0d/pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
 ]
+"pygments 2.13.0" = [
+    {url = "https://files.pythonhosted.org/packages/4f/82/672cd382e5b39ab1cd422a672382f08a1fb3d08d9e0c0f3707f33a52063b/Pygments-2.13.0-py3-none-any.whl", hash = "sha256:f643f331ab57ba3c9d89212ee4a2dabc6e94f117cf4eefde99a0574720d14c42"},
+    {url = "https://files.pythonhosted.org/packages/e0/ef/5905cd3642f2337d44143529c941cc3a02e5af16f0f65f81cbef7af452bb/Pygments-2.13.0.tar.gz", hash = "sha256:56a8508ae95f98e2b9bdf93a6be5ae3f7d8af858b43e02c5a2ff083726be40c1"},
+]
+"pyjq 2.6.0" = [
+    {url = "https://files.pythonhosted.org/packages/12/12/b1016128aed3ee6419b6aaa681e6a795747042a4b5eb24fc28bbe872484c/pyjq-2.6.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:6e0e4f398e81b1fb9794874d81fc9240d4a155adba5a1aecda77e717bcfae03e"},
+    {url = "https://files.pythonhosted.org/packages/8e/a7/678a3f5d458c9c1002adf4938a5df830448254423095ce68d2171abf5b21/pyjq-2.6.0.tar.gz", hash = "sha256:e083f326f4af8b07b8ca6424d1f99afbdd7db9b727284da5f919b9816077f2e4"},
+]
 "python-dotenv 0.21.0" = [
     {url = "https://files.pythonhosted.org/packages/2d/10/ff4f2f5b2a420fd09e1331d63cc87cf4367c5745c0a4ce99cea92b1cbacb/python_dotenv-0.21.0-py3-none-any.whl", hash = "sha256:1684eb44636dd462b66c3ee016599815514527ad99965de77f43e0944634a7e5"},
     {url = "https://files.pythonhosted.org/packages/87/8d/ab7352188f605e3f663f34692b2ed7457da5985857e9e4c2335cd12fb3c9/python-dotenv-0.21.0.tar.gz", hash = "sha256:b77d08274639e3d34145dfa6c7008e66df0f04b7be7a75fd0d5292c191d79045"},
@@ -484,6 +522,10 @@ content_hash = "sha256:547a365bc3ee8e424d3d639bd36e12f5d4baf608a1021e7d055a35b9b
 "rfc3986 1.5.0" = [
     {url = "https://files.pythonhosted.org/packages/79/30/5b1b6c28c105629cc12b33bdcbb0b11b5bb1880c6cfbd955f9e792921aa8/rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
     {url = "https://files.pythonhosted.org/packages/c4/e5/63ca2c4edf4e00657584608bee1001302bbf8c5f569340b78304f2f446cb/rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+]
+"rich 12.6.0" = [
+    {url = "https://files.pythonhosted.org/packages/11/23/814edf09ec6470d52022b9e95c23c1bef77f0bc451761e1504ebd09606d3/rich-12.6.0.tar.gz", hash = "sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"},
+    {url = "https://files.pythonhosted.org/packages/32/60/81ac2e7d1e3b861ab478a72e3b20fc91c4302acd2274822e493758941829/rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e"},
 ]
 "sniffio 1.3.0" = [
     {url = "https://files.pythonhosted.org/packages/c3/a0/5dba8ed157b0136607c7f2151db695885606968d1fae123dc3391e0cfdbf/sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
     "psycopg2>=2.9.5",
     "sqlalchemy>=1.4.45",
     "dynaconf>=3.1.11",
+    "pyjq>=2.6.0",
+    "rich>=12.6.0",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/recap/crawlers/db.py
+++ b/recap/crawlers/db.py
@@ -64,7 +64,7 @@ class Crawler:
                 self.storage.put_metadata(
                     self.infra,
                     self.instance,
-                    'columns',
+                    'schema',
                     columns,
                     schema,
                     view=view)
@@ -73,7 +73,7 @@ class Crawler:
                 self.storage.put_metadata(
                     self.infra,
                     self.instance,
-                    'columns',
+                    'schema',
                     columns,
                     schema,
                     table=table)

--- a/recap/search.py
+++ b/recap/search.py
@@ -1,0 +1,58 @@
+import pyjq
+from .storage.abstract import AbstractStorage
+from typing import List, Any
+
+class JqSearch:
+    def __init__(self, storage: AbstractStorage):
+        self.storage = storage
+
+    def search(self, infra: str, instance: str, query: str) -> List[dict[str, Any]]:
+        results = []
+        for schema in self.storage.list_schemas(infra, instance):
+            for table in self.storage.list_tables(infra, instance, schema):
+                doc = self._assemble_doc(infra, instance, schema, table=table)
+                matches = pyjq.first(query, doc)
+                if matches:
+                    results.append(doc)
+            for view in self.storage.list_views(infra, instance, schema):
+                doc = self._assemble_doc(infra, instance, schema, view=view)
+                matches = pyjq.first(query, doc)
+                if matches:
+                    results.append(doc)
+        return results
+
+    def _assemble_doc(
+        self,
+        infra: str,
+        instance: str,
+        schema: str,
+        table: str | None = None,
+        view: str | None = None,
+    ) -> dict[str, Any]:
+        table_or_view_key = 'table' if table else 'view'
+        aggregated_metadata = {}
+        metadata_types = self.storage.list_metadata(
+            infra,
+            instance,
+            schema,
+            table,
+            view
+        ) or []
+        for type in metadata_types:
+            metadata = self.storage.get_metadata(
+                infra,
+                instance,
+                type,
+                schema,
+                table,
+                view
+            )
+            aggregated_metadata[type] = metadata
+
+        return {
+            "infrastructure": infra,
+            "instance": instance,
+            "schema": schema,
+            table_or_view_key: table or view,
+            "metadata": aggregated_metadata,
+        }

--- a/recap/storage/recap.py
+++ b/recap/storage/recap.py
@@ -187,7 +187,7 @@ class RecapStorage(AbstractStorage):
                 "Schema must be set if putting view metadata"
             path = join(path, 'views', view)
         path = join(path, 'metadata', type)
-        self.client.get(path).json()
+        return self.client.get(path).json()
 
 
 @contextmanager


### PR DESCRIPTION
Add **very** basic search functionality. The implementation scans over all schemas, tables, and views. For each table/view metadata JSON document, a provided `jq` query string is executed against the document. If `jq` returns true, the document is included in the result set.

Here's an example query to find all tables with a `space_id` column:

    recap search postgresql sticker_space_dev \
        'contains({metadata: {schema: {columns: [{name: "space_id"}]}}})'

Known gaps:

* Only works with DBs right now (not filesystems, streams, etc)
* Search is a full scan (no indexing)
* Search is client side, which incurs a ton of overhead
* Does not inspect infra, instance, or schema metadata (only tables and views)
* JqSearch is hard coded (no ability to change search engines)
* and more...