### PR TITLE
Add list_infra and list_instances to storage

### DIFF
--- a/recap/api.py
+++ b/recap/api.py
@@ -130,6 +130,21 @@ def delete_view(
     )
 
 
+@app.get("/databases")
+def list_infra(
+    storage: AbstractStorage = Depends(get_storage),
+) -> List[str]:
+    return storage.list_infra()
+
+
+@app.get("/databases/{infra}/instances")
+def list_instances(
+    infra: str,
+    storage: AbstractStorage = Depends(get_storage),
+) -> List[str]:
+    return storage.list_instances(infra)
+
+
 @app.get("/databases/{infra}/instances/{instance}/schemas")
 def list_schemas(
     infra: str,

--- a/recap/storage/abstract.py
+++ b/recap/storage/abstract.py
@@ -61,6 +61,14 @@ class AbstractStorage(ABC):
         raise NotImplementedError
 
     @abstractmethod
+    def list_infra(self) -> List[str]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def list_instances(self, infra: str) -> List[str]:
+        raise NotImplementedError
+
+    @abstractmethod
     def list_schemas(self, infra: str, instance: str) -> List[str]:
         raise NotImplementedError
 

--- a/recap/storage/fs.py
+++ b/recap/storage/fs.py
@@ -19,7 +19,7 @@ class FilesystemStorage(AbstractStorage):
     def put_instance(self, infra: str, instance: str):
         dirname = join(
             self.root,
-            'databases',infra,
+            'databases', infra,
             'instances', instance,
         )
         self.fs.mkdirs(dirname, exist_ok=True)
@@ -176,6 +176,23 @@ class FilesystemStorage(AbstractStorage):
             # File is already deleted
             # TODO Maybe we should raise a StorageException here?
             pass
+
+    def list_infra(self) -> List[str]:
+        dirname = join(
+            self.root,
+            'databases'
+        )
+        infra = self.fs.ls(dirname, detail=False) if self.fs.exists(dirname) else []
+        return list(map(lambda p: basename(normpath(p)), infra))
+
+    def list_instances(self, infra: str) -> List[str]:
+        dirname = join(
+            self.root,
+            'databases', infra,
+            'instances'
+        )
+        instances = self.fs.ls(dirname, detail=False) if self.fs.exists(dirname) else []
+        return list(map(lambda p: basename(normpath(p)), instances))
 
     def list_schemas(self, infra: str, instance: str) -> List[str]:
         dirname = join(

--- a/recap/storage/recap.py
+++ b/recap/storage/recap.py
@@ -119,6 +119,15 @@ class RecapStorage(AbstractStorage):
         path = join(path, 'metadata', type)
         self.client.delete(path)
 
+    def list_infra(self) -> List[str]:
+        return self.client.get('databases').json()
+
+    def list_instances(self, infra: str) -> List[str]:
+        return self.client.get(join(
+            'databases', infra,
+            'instances'
+        )).json()
+
     def list_schemas(self, infra: str, instance: str) -> List[str]:
         return self.client.get(join(
             'databases', infra,


### PR DESCRIPTION
I realized there's no way to list infra and instances, so I've added it. Tada.

I want this for browsing and searching. Right now, search forces you to specify an infra and instance. Now users can just use their `jq` query string to search infra and instances. They can also search across all infra and instances.

While implementing the list methods, it's become apparent to me that I don't have the right infra abstraction in the storage layer. Everything in storage assumes you're dealing exclusively with /databases. When I go to add `fs` and `stream`, I'll need to refactor this code. C'est la vie.