### PR TITLE
Remove infra and instance params from `recap search`

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -32,13 +32,12 @@ def crawler():
 
 
 @app.command()
-def search(infra: str, instance: str, query: str):
-    import json
+def search(query: str):
     from recap.search import JqSearch
 
     with storage.open(**settings['storage']) as s:
         search = JqSearch(s)
-        results = search.search(infra, instance, query)
+        results = search.search(query)
         print_json(data=results)
 
 

--- a/recap/search.py
+++ b/recap/search.py
@@ -6,19 +6,21 @@ class JqSearch:
     def __init__(self, storage: AbstractStorage):
         self.storage = storage
 
-    def search(self, infra: str, instance: str, query: str) -> List[dict[str, Any]]:
+    def search(self, query: str) -> List[dict[str, Any]]:
         results = []
-        for schema in self.storage.list_schemas(infra, instance):
-            for table in self.storage.list_tables(infra, instance, schema):
-                doc = self._assemble_doc(infra, instance, schema, table=table)
-                matches = pyjq.first(query, doc)
-                if matches:
-                    results.append(doc)
-            for view in self.storage.list_views(infra, instance, schema):
-                doc = self._assemble_doc(infra, instance, schema, view=view)
-                matches = pyjq.first(query, doc)
-                if matches:
-                    results.append(doc)
+        for infra in self.storage.list_infra():
+            for instance in self.storage.list_instances(infra):
+                for schema in self.storage.list_schemas(infra, instance):
+                    for table in self.storage.list_tables(infra, instance, schema):
+                        doc = self._assemble_doc(infra, instance, schema, table=table)
+                        matches = pyjq.first(query, doc)
+                        if matches:
+                            results.append(doc)
+                    for view in self.storage.list_views(infra, instance, schema):
+                        doc = self._assemble_doc(infra, instance, schema, view=view)
+                        matches = pyjq.first(query, doc)
+                        if matches:
+                            results.append(doc)
         return results
 
     def _assemble_doc(


### PR DESCRIPTION
Search used to require infra and instance params. This was bad because it restricted users to searching just a single instance. It also made it confusing since you could reference the infra and instance fields inside the `jq` query as well. But referencing the `jq` query only ever saw documents in the infra/instance that were supplied via the parameters.

Anyway, I removed the parameters, and search queries can now span the entire catalog. Users can now search like this:

    recap search 'contains({metadata: {schema: {columns: [{name: "space_id"}]}}})'

See the previous commit comment for a bit more about this.