### PR TITLE
Add `recap list` and `recap read` commands

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -41,5 +41,64 @@ def search(query: str):
         print_json(data=results)
 
 
+@app.command()
+def list(
+    infra: str | None = None,
+    instance: str | None = None,
+    schema: str | None = None,
+    table: str | None = None,
+    view: str | None = None,
+):
+    with storage.open(**settings['storage']) as s:
+        children = []
+        if not instance:
+            children = s.list_infra()
+        elif not instance:
+            children = s.list_instance(infra)
+        elif not schema:
+            children = s.list_schemas(infra, instance)
+        elif table:
+            children = s.list_metadata(
+                infra,
+                instance,
+                schema,
+                table=table,
+            )
+        elif view:
+            children = s.list_metadata(
+                infra,
+                instance,
+                schema,
+                view=view,
+            )
+        else:
+            children = {
+                'tables': s.list_tables(infra, instance, schema),
+                'views': s.list_views(infra, instance, schema),
+            }
+        print_json(data=children)
+
+
+@app.command()
+def read(
+    infra: str,
+    instance: str,
+    type: str,
+    schema: str | None = None,
+    table: str | None = None,
+    view: str | None = None,
+):
+    with storage.open(**settings['storage']) as s:
+        metadata = s.get_metadata(
+            infra,
+            instance,
+            type,
+            schema,
+            table,
+            view,
+        )
+        print_json(data=metadata)
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
Continuting with the search theme, I'm adding some basic read commands now.

`recap list` lists children for infra, instances, schemas, tables, and views. Here's an example that lists metadata for the `spaces` table:

    recap list --infra postgresql --instance sticker_space_dev \
        --schema public --table spaces

`recap read` reads metadata for infra, instances, schemas, tables, ans views. Here's an example that reads `schema` metadata for the `spaces` table:

    pdm run recap read postgresql sticker_space_dev schema \
        --schema public --table spaces

While implementing, I noticed that we have a bunch of list methods in the storage layer:

* list_infra
* list_instances
* list_schemas
* list_tables
* list_views
* list_metadata

I think I'm going to combine these into one `list()` method in my next commit.