### PR TITLE
Use paths for read APIs

### DIFF
--- a/recap/api.py
+++ b/recap/api.py
@@ -1,7 +1,7 @@
 from .config import settings
 from . import storage
 from .storage.abstract import AbstractStorage
-from fastapi import Body, Depends, FastAPI
+from fastapi import Body, Depends, FastAPI, Request
 from typing import Any, List, Generator
 
 
@@ -130,101 +130,25 @@ def delete_view(
     )
 
 
-@app.get("/databases")
-def list_infra(
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str]:
-    return storage.list_infra()
-
-
-@app.get("/databases/{infra}/instances")
-def list_instances(
-    infra: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str]:
-    return storage.list_instances(infra)
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas")
-def list_schemas(
-    infra: str,
-    instance: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str]:
-    return storage.list_schemas(
-        infra,
-        instance
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas/{schema}/tables")
-def list_tables(
-    infra: str,
-    instance: str,
-    schema: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str]:
-    return storage.list_tables(
-        infra,
-        instance,
-        schema
-    )
-
-
-@app.get("/databases/{infra}/{instance}/schemas/{schema}/views")
-def list_views(
-    infra: str,
-    instance: str,
-    schema: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str]:
-    return storage.list_views(
-        infra,
-        instance,
-        schema
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/metadata")
-def list_instance_metadata(
-    infra: str,
-    instance: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str] | None:
-    return storage.list_metadata(
-        infra,
-        instance
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/metadata/{type}")
-def get_instance_metadata(
-    infra: str,
-    instance: str,
+# WARN: This has to go before list() since it's a more specific path
+@app.get("/{path:path}/metadata/{type}")
+def get_metadata(
+    path: str,
     type: str,
     storage: AbstractStorage = Depends(get_storage),
 ) -> dict[str, str] | None:
     return storage.get_metadata(
-        infra,
-        instance,
-        type
-    )
-
-
-@app.put("/databases/{infra}/instances/{instance}/metadata/{type}")
-def put_instance_metadata(
-    infra: str,
-    instance: str,
-    type: str,
-    metadata: dict[str, Any] = Body(...),
-    storage: AbstractStorage = Depends(get_storage),
-):
-    return storage.put_metadata(
-        infra,
-        instance,
+        path,
         type,
-        metadata
     )
+
+
+@app.get("/{path:path}")
+def list(
+    path: str,
+    storage: AbstractStorage = Depends(get_storage),
+) -> List[str]:
+    return storage.list(path) or []
 
 
 @app.delete("/databases/{infra}/instances/{instance}/metadata/{type}")
@@ -238,36 +162,6 @@ def delete_instance_metadata(
         infra,
         instance,
         type
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas/{schema}/metadata")
-def list_schema_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str] | None:
-    return storage.list_metadata(
-        infra,
-        instance,
-        schema
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas/{schema}/metadata/{type}")
-def get_schema_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    type: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> dict[str, str] | None:
-    return storage.get_metadata(
-        infra,
-        instance,
-        type,
-        schema
     )
 
 
@@ -302,40 +196,6 @@ def delete_schema_metadata(
         instance,
         type,
         schema
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas/{schema}/tables/{table}/metadata")
-def list_table_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    table: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str] | None:
-    return storage.list_metadata(
-        infra,
-        instance,
-        schema,
-        table=table
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas/{schema}/tables/{table}/metadata/{type}")
-def get_table_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    table: str,
-    type: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> dict[str, str] | None:
-    return storage.get_metadata(
-        infra,
-        instance,
-        type,
-        schema,
-        table=table
     )
 
 
@@ -374,35 +234,6 @@ def delete_table_metadata(
         type,
         schema,
         table=table
-    )
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas/{schema}/views/{view}/metadata")
-def list_view_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    view: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> List[str] | None:
-    return storage.list_metadata(infra, instance, schema, view=view)
-
-
-@app.get("/databases/{infra}/instances/{instance}/schemas/{schema}/views/{view}/metadata/{type}")
-def get_view_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    view: str,
-    type: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> dict[str, str] | None:
-    return storage.get_metadata(
-        infra,
-        instance,
-        type,
-        schema,
-        view=view
     )
 
 

--- a/recap/cli.py
+++ b/recap/cli.py
@@ -36,6 +36,7 @@ def search(query: str):
     from recap.search import JqSearch
 
     with storage.open(**settings['storage']) as s:
+        # TODO should allow users to specify a path to start search in
         search = JqSearch(s)
         results = search.search(query)
         print_json(data=results)
@@ -43,61 +44,26 @@ def search(query: str):
 
 @app.command()
 def list(
-    infra: str | None = None,
-    instance: str | None = None,
-    schema: str | None = None,
-    table: str | None = None,
-    view: str | None = None,
+    path: str = typer.Argument('/')
 ):
+    from recap.search import JqSearch
+
     with storage.open(**settings['storage']) as s:
-        children = []
-        if not instance:
-            children = s.list_infra()
-        elif not instance:
-            children = s.list_instance(infra)
-        elif not schema:
-            children = s.list_schemas(infra, instance)
-        elif table:
-            children = s.list_metadata(
-                infra,
-                instance,
-                schema,
-                table=table,
-            )
-        elif view:
-            children = s.list_metadata(
-                infra,
-                instance,
-                schema,
-                view=view,
-            )
-        else:
-            children = {
-                'tables': s.list_tables(infra, instance, schema),
-                'views': s.list_views(infra, instance, schema),
-            }
-        print_json(data=children)
+        search = JqSearch(s)
+        results = search.list(path)
+        print_json(data=results)
 
 
 @app.command()
 def read(
-    infra: str,
-    instance: str,
-    type: str,
-    schema: str | None = None,
-    table: str | None = None,
-    view: str | None = None,
+    path: str
 ):
+    from recap.search import JqSearch
+
     with storage.open(**settings['storage']) as s:
-        metadata = s.get_metadata(
-            infra,
-            instance,
-            type,
-            schema,
-            table,
-            view,
-        )
-        print_json(data=metadata)
+        search = JqSearch(s)
+        results = search.read(path)
+        print_json(data=results)
 
 
 if __name__ == "__main__":

--- a/recap/crawlers/db.py
+++ b/recap/crawlers/db.py
@@ -1,5 +1,6 @@
 import sqlalchemy as sa
 from contextlib import contextmanager
+from pathlib import PosixPath
 from recap.storage.abstract import AbstractStorage
 from typing import List, Generator
 
@@ -83,10 +84,11 @@ class Crawler:
 
     # TODO Combine methods using a util that is agnostic the data being removed
     def _remove_deleted_schemas(self, schemas: List[str]):
-        storage_schemas = self.storage.list_schemas(
-            self.infra,
-            self.instance
-        )
+        storage_schemas = self.storage.list(str(PosixPath(
+            'databases', self.infra,
+            'instances', self.instance,
+            'schemas'
+        ))) or []
         # Find schemas that are not currently in nstance
         schemas_to_remove = [s for s in storage_schemas if s not in schemas]
         for schema in schemas_to_remove:
@@ -96,11 +98,12 @@ class Crawler:
             )
 
     def _remove_deleted_tables(self, schema: str, tables: List[str]):
-        storage_tables = self.storage.list_tables(
-            self.infra,
-            self.instance,
-            schema
-        )
+        storage_tables = self.storage.list(str(PosixPath(
+            'databases', self.infra,
+            'instances', self.instance,
+            'schemas', schema,
+            'tables'
+        ))) or []
         # Find schemas that are not currently in nstance
         tables_to_remove = [t for t in storage_tables if t not in tables]
         for table in tables_to_remove:
@@ -112,11 +115,12 @@ class Crawler:
             )
 
     def _remove_deleted_views(self, schema: str, views: List[str]):
-        storage_views = self.storage.list_views(
-            self.infra,
-            self.instance,
-            schema
-        )
+        storage_views = self.storage.list(str(PosixPath(
+            'databases', self.infra,
+            'instances', self.instance,
+            'schemas', schema,
+            'views'
+        ))) or []
         # Find schemas that are not currently in nstance
         views_to_remove = [v for v in storage_views if v not in views]
         for view in views_to_remove:

--- a/recap/search.py
+++ b/recap/search.py
@@ -1,60 +1,68 @@
 import pyjq
 from .storage.abstract import AbstractStorage
+from pathlib import PosixPath
 from typing import List, Any
 
 class JqSearch:
     def __init__(self, storage: AbstractStorage):
         self.storage = storage
 
-    def search(self, query: str) -> List[dict[str, Any]]:
-        results = []
-        for infra in self.storage.list_infra():
-            for instance in self.storage.list_instances(infra):
-                for schema in self.storage.list_schemas(infra, instance):
-                    for table in self.storage.list_tables(infra, instance, schema):
-                        doc = self._assemble_doc(infra, instance, schema, table=table)
-                        matches = pyjq.first(query, doc)
-                        if matches:
-                            results.append(doc)
-                    for view in self.storage.list_views(infra, instance, schema):
-                        doc = self._assemble_doc(infra, instance, schema, view=view)
-                        matches = pyjq.first(query, doc)
-                        if matches:
-                            results.append(doc)
-        return results
+    def list(self, path: str):
+        return self.storage.list(path)
 
-    def _assemble_doc(
+    def read(
         self,
-        infra: str,
-        instance: str,
-        schema: str,
-        table: str | None = None,
-        view: str | None = None,
+        path: str,
     ) -> dict[str, Any]:
-        table_or_view_key = 'table' if table else 'view'
+        metadata_path = PosixPath(path, 'metadata')
+        metadata_types = self.storage.list(str(metadata_path)) or []
         aggregated_metadata = {}
-        metadata_types = self.storage.list_metadata(
-            infra,
-            instance,
-            schema,
-            table,
-            view
-        ) or []
         for type in metadata_types:
             metadata = self.storage.get_metadata(
-                infra,
-                instance,
+                path,
                 type,
-                schema,
-                table,
-                view
             )
             aggregated_metadata[type] = metadata
 
-        return {
-            "infrastructure": infra,
-            "instance": instance,
-            "schema": schema,
-            table_or_view_key: table or view,
+        components_doc = self._assemble_path_components(PosixPath(path))
+
+        return components_doc | {
             "metadata": aggregated_metadata,
         }
+
+    def search(self, query: str) -> List[dict[str, Any]]:
+        results = []
+        path_stack = [PosixPath('/')]
+        while path_stack:
+            path = path_stack.pop()
+
+            if path.name == 'metadata':
+                doc = self.read(str(path.parent))
+                matches = pyjq.first(query, doc)
+                if matches:
+                    results.append(doc)
+            else:
+                children = self.storage.list(str(path)) or []
+                children = map(lambda c: PosixPath(path, c), children)
+                path_stack.extend(children)
+
+        return results
+
+    def _assemble_path_components(self, path: PosixPath) -> dict[str, str]:
+        components_doc = {}
+        path_parts = list(path.parts)
+
+        # Get rid of leading separator if it's there
+        if path_parts[0] == '/':
+            path_parts = path_parts[1:]
+
+        # Path format is always something like:
+        #     /databases/<infra>/instances/<myinstance>/etc
+        # So split the path up and pop off values and keys to add to the doc.
+        # TODO singularize plural keys for user convenience
+        while path_parts:
+            v = path_parts.pop()
+            k = path_parts.pop()
+            components_doc[k] = v
+
+        return components_doc

--- a/recap/storage/abstract.py
+++ b/recap/storage/abstract.py
@@ -60,45 +60,18 @@ class AbstractStorage(ABC):
     ):
         raise NotImplementedError
 
+    # TODO Maybe we should just take path: str here?
     @abstractmethod
-    def list_infra(self) -> List[str]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def list_instances(self, infra: str) -> List[str]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def list_schemas(self, infra: str, instance: str) -> List[str]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def list_tables(self, infra: str, instance: str, schema: str) -> List[str]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def list_views(self, infra: str, instance: str, schema: str) -> List[str]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def list_metadata(
+    def list(
         self,
-        infra: str,
-        instance: str,
-        schema: str | None = None,
-        table: str | None = None,
-        view: str | None = None,
+        path: str
     ) -> List[str] | None:
         raise NotImplementedError
 
     @abstractmethod
     def get_metadata(
         self,
-        infra: str,
-        instance: str,
+        path: str,
         type: str,
-        schema: str | None = None,
-        table: str | None = None,
-        view: str | None = None,
     ) -> dict[str, str] | None:
         raise NotImplementedError

--- a/recap/storage/recap.py
+++ b/recap/storage/recap.py
@@ -119,84 +119,19 @@ class RecapStorage(AbstractStorage):
         path = join(path, 'metadata', type)
         self.client.delete(path)
 
-    def list_infra(self) -> List[str]:
-        return self.client.get('databases').json()
-
-    def list_instances(self, infra: str) -> List[str]:
-        return self.client.get(join(
-            'databases', infra,
-            'instances'
-        )).json()
-
-    def list_schemas(self, infra: str, instance: str) -> List[str]:
-        return self.client.get(join(
-            'databases', infra,
-            'instances', instance,
-            'schemas'
-        )).json()
-
-    def list_tables(self, infra: str, instance: str, schema: str) -> List[str]:
-        return self.client.get(join(
-            'databases', infra,
-            'instances', instance,
-            'schemas', schema,
-            'tables'
-        )).json()
-
-    def list_views(self, infra: str, instance: str, schema: str) -> List[str]:
-        return self.client.get(join(
-            'databases', infra,
-            'instances', instance,
-            'schemas', schema,
-            'views'
-        )).json()
-
-    def list_metadata(
+    def list(
         self,
-        infra: str,
-        instance: str,
-        schema: str | None = None,
-        table: str | None = None,
-        view: str | None = None,
+        path: str
     ) -> List[str] | None:
-        # TODO this code is dupe'd all over
-        path = join('databases', infra, 'instances', instance)
-        if schema:
-            path = join(path, 'schemas', schema)
-        if table:
-            assert schema is not None, \
-                "Schema must be set if putting table metadata"
-            path = join(path, 'tables', table)
-        elif view:
-            assert schema is not None, \
-                "Schema must be set if putting view metadata"
-            path = join(path, 'views', view)
-        path = join(path, 'metadata')
         return self.client.get(path).json()
+
 
     def get_metadata(
         self,
-        infra: str,
-        instance: str,
+        path: str,
         type: str,
-        schema: str | None = None,
-        table: str | None = None,
-        view: str | None = None,
     ) -> dict[str, str] | None:
-        # TODO this code is dupe'd all over
-        path = join('databases', infra, 'instances', instance)
-        if schema:
-            path = join(path, 'schemas', schema)
-        if table:
-            assert schema is not None, \
-                "Schema must be set if putting table metadata"
-            path = join(path, 'tables', table)
-        elif view:
-            assert schema is not None, \
-                "Schema must be set if putting view metadata"
-            path = join(path, 'views', view)
-        path = join(path, 'metadata', type)
-        return self.client.get(path).json()
+        return self.client.get(join(path, 'metadata', type)).json()
 
 
 @contextmanager


### PR DESCRIPTION
Replace list_* and get_metadata methods with a single list() and get_metadata() API that simply takes a path. This path-based implementation feels right. It's much more flexible, and simplified the code a lot.

As a result of this refactor, the CLI has changed slightly. THe `list` and`read` now

    recap list \
        /databases/postgresql/instances/sticker_space_dev/schemas/public/tables

    recap read \
        /databases/postgresql/instances/sticker_space_dev/schemas/public/tables/spaces

I also moved the list and read logic into JqSearch. At some point I'll have to rename JqSearch since these methods don't have much to do with search, but it's fine for now.

Paths might be slightly less friendly to end-users. I could imagine wanting to provide helper argumnets like --database --instance and so on. I'm going to leave that for another day, though.