### PR TITLE
Use paths for read, write, and list in storage

### DIFF
--- a/recap/api.py
+++ b/recap/api.py
@@ -2,6 +2,7 @@ from .config import settings
 from . import storage
 from .storage.abstract import AbstractStorage
 from fastapi import Body, Depends, FastAPI, Request
+from pathlib import PurePosixPath
 from typing import Any, List, Generator
 
 
@@ -13,263 +14,39 @@ def get_storage() -> Generator[AbstractStorage, None, None]:
         yield s
 
 
-# TODO re-order APIs based on instance, schema, table, view, metadata
-@app.put("/databases/{infra}/instances/{instance}")
-def put_instance(
-    infra: str,
-    instance: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.put_instance(
-        infra,
-        instance
-    )
-
-
-@app.put("/databases/{infra}/instances/{instance}/schemas/{schema}")
-def put_schema(
-    infra: str,
-    instance: str,
-    schema: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.put_schema(
-        infra,
-        instance,
-        schema
-    )
-
-
-@app.put("/databases/{infra}/instances/{instance}/schemas/{schema}/tables/{table}")
-def put_table(
-    infra: str,
-    instance: str,
-    schema: str,
-    table: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.put_table(
-        infra,
-        instance,
-        schema,
-        table
-    )
-
-
-@app.put("/databases/{infra}/instances/{instance}/schemas/{schema}/views/{view}")
-def put_view(
-    infra: str,
-    instance: str,
-    schema: str,
-    view: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.put_view(
-        infra,
-        instance,
-        schema,
-        view
-    )
-
-
-@app.delete("/databases/{infra}/instances/{instance}")
-def delete_instance(
-    infra: str,
-    instance: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.remove_instance(
-        infra,
-        instance
-    )
-
-
-@app.delete("/databases/{infra}/instances/{instance}/schemas/{schema}")
-def delete_schema(
-    infra: str,
-    instance: str,
-    schema: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.remove_schema(
-        infra,
-        instance,
-        schema
-    )
-
-
-@app.delete("/databases/{infra}/instances/{instance}/schemas/{schema}/tables/{table}")
-def delete_table(
-    infra: str,
-    instance: str,
-    schema: str,
-    table: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.remove_table(
-        infra,
-        instance,
-        schema,
-        table
-    )
-
-
-@app.delete("/databases/{infra}/instances/{instance}/schemas/{schema}/views/{view}")
-def delete_view(
-    infra: str,
-    instance: str,
-    schema: str,
-    view: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    storage.remove_view(
-        infra,
-        instance,
-        schema,
-        view
-    )
-
-
-# WARN: This has to go before list() since it's a more specific path
-@app.get("/{path:path}/metadata/{type}")
-def get_metadata(
-    path: str,
-    type: str,
-    storage: AbstractStorage = Depends(get_storage),
-) -> dict[str, str] | None:
-    return storage.get_metadata(
-        path,
-        type,
-    )
-
-
 @app.get("/{path:path}")
-def list(
+def get_path(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
     path: str,
+    read: bool | None = None,
     storage: AbstractStorage = Depends(get_storage),
-) -> List[str]:
-    return storage.list(path) or []
+) -> List[str] | dict[str, Any]:
+    # TODO should probably return a 404 if we get None fro storage
+    if read:
+        return storage.read(PurePosixPath(path)) or {}
+    else:
+        return storage.ls(PurePosixPath(path)) or []
 
 
-@app.delete("/databases/{infra}/instances/{instance}/metadata/{type}")
-def delete_instance_metadata(
-    infra: str,
-    instance: str,
-    type: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    return storage.remove_metadata(
-        infra,
-        instance,
-        type
-    )
-
-
-@app.put("/databases/{infra}/instances/{instance}/schemas/{schema}/metadata/{type}")
-def put_schema_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    type: str,
-    metadata: dict[str, Any] = Body(...),
+@app.put("/{path:path}")
+def put_path(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    type: str | None = None,
+    metadata: Any = Body(default=None),
     storage: AbstractStorage = Depends(get_storage),
 ):
-    return storage.put_metadata(
-        infra,
-        instance,
-        type,
-        metadata,
-        schema
-    )
+    if type and metadata:
+        storage.write(PurePosixPath(path), type, metadata)
+    else:
+        return storage.touch(PurePosixPath(path))
 
 
-@app.delete("/databases/{infra}/instances/{instance}/schemas/{schema}/metadata/{type}")
-def delete_schema_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    type: str,
+@app.delete("/{path:path}")
+def delete_path(
+    # TODO Make this a PurePosixPath type. FastAPI is hassling me right now.
+    path: str,
+    type: str | None = None,
     storage: AbstractStorage = Depends(get_storage),
 ):
-    return storage.remove_metadata(
-        infra,
-        instance,
-        type,
-        schema
-    )
-
-
-@app.put("/databases/{infra}/instances/{instance}/schemas/{schema}/tables/{table}/metadata/{type}")
-def put_table_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    table: str,
-    type: str,
-    metadata: dict[str, Any] = Body(...),
-    storage: AbstractStorage = Depends(get_storage),
-):
-    return storage.put_metadata(
-        infra,
-        instance,
-        type,
-        metadata,
-        schema,
-        table=table
-    )
-
-
-@app.delete("/databases/{infra}/instances/{instance}/schemas/{schema}/tables/{table}/metadata/{type}")
-def delete_table_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    table: str,
-    type: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    return storage.remove_metadata(
-        infra,
-        instance,
-        type,
-        schema,
-        table=table
-    )
-
-
-@app.put("/databases/{infra}/instances/{instance}/schemas/{schema}/views/{view}/metadata/{type}")
-def put_view_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    view: str,
-    type: str,
-    metadata: dict[str, Any] = Body(...),
-    storage: AbstractStorage = Depends(get_storage),
-):
-    return storage.put_metadata(
-        infra,
-        instance,
-        type,
-        metadata,
-        schema,
-        view=view
-    )
-
-
-@app.delete("/databases/{infra}/instances/{instance}/schemas/{schema}/views/{view}/metadata/{type}")
-def delete_view_metadata(
-    infra: str,
-    instance: str,
-    schema: str,
-    view: str,
-    type: str,
-    storage: AbstractStorage = Depends(get_storage),
-):
-    return storage.remove_metadata(
-        infra,
-        instance,
-        type,
-        schema,
-        view=view
-    )
+    storage.rm(PurePosixPath(path), type)

--- a/recap/search.py
+++ b/recap/search.py
@@ -1,6 +1,6 @@
 import pyjq
 from .storage.abstract import AbstractStorage
-from pathlib import PosixPath
+from pathlib import PurePosixPath
 from typing import List, Any
 
 class JqSearch:
@@ -8,61 +8,29 @@ class JqSearch:
         self.storage = storage
 
     def list(self, path: str):
-        return self.storage.list(path)
+        return self.storage.ls(PurePosixPath(path))
 
     def read(
         self,
         path: str,
     ) -> dict[str, Any]:
-        metadata_path = PosixPath(path, 'metadata')
-        metadata_types = self.storage.list(str(metadata_path)) or []
-        aggregated_metadata = {}
-        for type in metadata_types:
-            metadata = self.storage.get_metadata(
-                path,
-                type,
-            )
-            aggregated_metadata[type] = metadata
-
-        components_doc = self._assemble_path_components(PosixPath(path))
-
-        return components_doc | {
-            "metadata": aggregated_metadata,
-        }
+        return self.storage.read(PurePosixPath(path)) or {}
 
     def search(self, query: str) -> List[dict[str, Any]]:
         results = []
-        path_stack = [PosixPath('/')]
+        path_stack = [PurePosixPath('/')]
+
         while path_stack:
             path = path_stack.pop()
+            doc = self.read(str(path))
 
-            if path.name == 'metadata':
-                doc = self.read(str(path.parent))
-                matches = pyjq.first(query, doc)
-                if matches:
-                    results.append(doc)
-            else:
-                children = self.storage.list(str(path)) or []
-                children = map(lambda c: PosixPath(path, c), children)
-                path_stack.extend(children)
+            # If the doc matches the query, add it to the results
+            if pyjq.first(query, doc):
+                results.append(doc)
+
+            # Now add any children to the stack for processing
+            children = self.storage.ls(path) or []
+            children = map(lambda c: PurePosixPath(path, c), children)
+            path_stack.extend(children)
 
         return results
-
-    def _assemble_path_components(self, path: PosixPath) -> dict[str, str]:
-        components_doc = {}
-        path_parts = list(path.parts)
-
-        # Get rid of leading separator if it's there
-        if path_parts[0] == '/':
-            path_parts = path_parts[1:]
-
-        # Path format is always something like:
-        #     /databases/<infra>/instances/<myinstance>/etc
-        # So split the path up and pop off values and keys to add to the doc.
-        # TODO singularize plural keys for user convenience
-        while path_parts:
-            v = path_parts.pop()
-            k = path_parts.pop()
-            components_doc[k] = v
-
-        return components_doc

--- a/recap/storage/abstract.py
+++ b/recap/storage/abstract.py
@@ -1,77 +1,63 @@
 from abc import ABC, abstractmethod
+from pathlib import PurePosixPath
 from typing import Any, List
 
 
 class AbstractStorage(ABC):
     @abstractmethod
-    def put_instance(self, infra: str, instance: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def put_schema(self, infra: str, instance: str, schema: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def put_table(self, infra: str, instance: str, schema: str, table: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def put_view(self, infra: str, instance: str, schema: str, view: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def put_metadata(
+    def touch(
         self,
-        infra: str,
-        instance: str,
-        type: str,
-        metadata: dict[str, Any],
-        schema: str | None = None,
-        table: str | None = None,
-        view: str | None = None,
+        path: PurePosixPath,
     ):
         raise NotImplementedError
 
     @abstractmethod
-    def remove_instance(self, infra: str, instance: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def remove_schema(self, infra: str, instance: str, schema: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def remove_table(self, infra: str, instance: str, schema: str, table: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def remove_view(self, infra: str, instance: str, schema: str, view: str):
-        raise NotImplementedError
-
-    @abstractmethod
-    def remove_metadata(
+    def write(
         self,
-        infra: str,
-        instance: str,
+        path: PurePosixPath,
         type: str,
-        schema: str | None = None,
-        table: str | None = None,
-        view: str | None = None,
+        metadata: Any,
     ):
         raise NotImplementedError
 
-    # TODO Maybe we should just take path: str here?
     @abstractmethod
-    def list(
+    def rm(
         self,
-        path: str
+        path: PurePosixPath,
+        type: str | None = None,
+    ):
+        raise NotImplementedError
+
+    @abstractmethod
+    def ls(
+        self,
+        path: PurePosixPath,
     ) -> List[str] | None:
         raise NotImplementedError
 
     @abstractmethod
-    def get_metadata(
+    def read(
         self,
-        path: str,
-        type: str,
-    ) -> dict[str, str] | None:
+        path: PurePosixPath,
+    ) -> dict[str, Any] | None:
         raise NotImplementedError
+
+    # TODO Not sure this really belongs here...
+    def _path_components_dict(self, path: PurePosixPath) -> dict[str, str]:
+        components_doc = {}
+        path_parts = list(path.parts)
+
+        # Get rid of leading separator if it's there
+        if path_parts[0] == '/':
+            path_parts = path_parts[1:]
+
+        # Path format is always something like:
+        #     /databases/<infra>/instances/<myinstance>/etc
+        # So split the path up and pop off values and keys to add to the doc.
+        # TODO singularize plural keys for user convenience
+        while path_parts:
+            v = path_parts.pop()
+            k = path_parts.pop()
+            components_doc[k] = v
+
+        return components_doc


### PR DESCRIPTION
I've gotten rid of all the specialty put_ and remove_ methods in the storage layer. Everything works off of paths now. Everything feels very ergonomic after making the change. The storage layer should now support things like streams and filesystems now, not just databases.

The change also makes it possible to store metadata at any layer, not just tables and views. The FilesystemStorage writes metadata in files named `[type].json`. When read is called on FilesystemStorage, the various types are stitched together into a single document.

For example, a directory with two files `columns.json` and `pii.json` would be rendered like so:

```
{
    "columns": {...}
    "pii": {...}
}
```

FilesystemStorage also includes path details in the document. This is done by splitting the path into tuples of (k, v) and including the pairs in the returned document.

For example, a path:

    /databases/my_db/instances/my_instance/schemas/my_schema/tables/my_table

Would have the following key/value pairs included when the path is read:

```
{
    "databases": "my_db",
    "instances": "my_instance",
    "schemas": "my_schema",
    "tables": "my_table,
    ...
}
```

Some of the `recap` commands have also changed slightly. Here's what they look like now:

```
recap list /databases/postgresql/instances/sticker_space_dev/schemas/public/tables
recap search 'contains({columns: [{name: "space_id"}]})'
recap read /databases/postgresql/instances/sticker_space_dev/schemas/public/tables/managers
```