### PR TITLE
Set location metadata in DB crawler

### DIFF
--- a/recap/storage/abstract.py
+++ b/recap/storage/abstract.py
@@ -41,23 +41,3 @@ class AbstractStorage(ABC):
         path: PurePosixPath,
     ) -> dict[str, Any] | None:
         raise NotImplementedError
-
-    # TODO Not sure this really belongs here...
-    def _path_components_dict(self, path: PurePosixPath) -> dict[str, str]:
-        components_doc = {}
-        path_parts = list(path.parts)
-
-        # Get rid of leading separator if it's there
-        if path_parts[0] == '/':
-            path_parts = path_parts[1:]
-
-        # Path format is always something like:
-        #     /databases/<infra>/instances/<myinstance>/etc
-        # So split the path up and pop off values and keys to add to the doc.
-        # TODO singularize plural keys for user convenience
-        while path_parts:
-            v = path_parts.pop()
-            k = path_parts.pop()
-            components_doc[k] = v
-
-        return components_doc

--- a/recap/storage/fs.py
+++ b/recap/storage/fs.py
@@ -84,7 +84,7 @@ class FilesystemStorage(AbstractStorage):
                     type = PurePosixPath(child['name']).with_suffix('').name
                     with self.fs.open(child['name'], 'r') as f:
                         doc[type] = json.load(f)
-            return (self._path_components_dict(path) | doc) if doc else None
+            return doc
         except FileNotFoundError:
             # File is already deleted
             # TODO Maybe we should raise a StorageException here?


### PR DESCRIPTION
FilesystemStorage used to magically set the database, instance, schema, table, and view fields at read-time using a DB's path param. This never sat well with me. It was DB-specific and treated differently than standard metadata types.

I've moved this logic to the write-time side. Crawlers are now expected to write location metadata the same as any other metadata type. I've updated the DB crawler to do this. Things feel much better this way.