### PR TITLE
Add DuckDB search and indexer

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -35,6 +35,14 @@ version = "0.9.1"
 summary = "Python parser for the CommonMark Markdown spec"
 
 [[package]]
+name = "duckdb"
+version = "0.6.1"
+summary = "DuckDB embedded database"
+dependencies = [
+    "numpy>=1.14",
+]
+
+[[package]]
 name = "dynaconf"
 version = "3.1.11"
 requires_python = ">=3.7"
@@ -103,6 +111,12 @@ name = "idna"
 version = "3.4"
 requires_python = ">=3.5"
 summary = "Internationalized Domain Names in Applications (IDNA)"
+
+[[package]]
+name = "numpy"
+version = "1.23.5"
+requires_python = ">=3.8"
+summary = "NumPy is the fundamental package for array computing with Python."
 
 [[package]]
 name = "psycopg2"
@@ -256,7 +270,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:b18a02087d809a43d22ca292504dbd8cf6934f1c9c5406f10b247ea87122795a"
+content_hash = "sha256:4f890e95dba6a21ae762d6dc4f2a8066cff44adf8ca4339730c25ad32cc44b18"
 
 [metadata.files]
 "anyio 3.6.2" = [
@@ -278,6 +292,55 @@ content_hash = "sha256:b18a02087d809a43d22ca292504dbd8cf6934f1c9c5406f10b247ea87
 "commonmark 0.9.1" = [
     {url = "https://files.pythonhosted.org/packages/60/48/a60f593447e8f0894ebb7f6e6c1f25dafc5e89c5879fdc9360ae93ff83f0/commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
     {url = "https://files.pythonhosted.org/packages/b1/92/dfd892312d822f36c55366118b95d914e5f16de11044a27cf10a7d71bbbf/commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
+]
+"duckdb 0.6.1" = [
+    {url = "https://files.pythonhosted.org/packages/01/09/f54f14b256a7b4cc928bffeacd5520b40e3baeb54c7f4131ffc9b35af122/duckdb-0.6.1-cp36-cp36m-win32.whl", hash = "sha256:546a1cd17595bd1dd009daf6f36705aa6f95337154360ce44932157d353dcd80"},
+    {url = "https://files.pythonhosted.org/packages/09/4d/5baca267898d4d290a9dabe3d6d023cba38fb1774234f7fa4cc069a02638/duckdb-0.6.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fec2c2466654ce786843bda2bfba71e0e4719106b41d36b17ceb1901e130aa71"},
+    {url = "https://files.pythonhosted.org/packages/14/ea/1df38c8d38fd83e766dee978cde7fa3c4799cd4ed3de40b76de62daecc3e/duckdb-0.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0c7155cb93ab432eca44b651256c359281d26d927ff43badaf1d2276dd770832"},
+    {url = "https://files.pythonhosted.org/packages/18/38/04ad06607c9b537ed0db64cab5ddc397c72ef21d66db830892124792f6ba/duckdb-0.6.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d218c2dd3bda51fb79e622b7b2266183ac9493834b55010aa01273fa5b7a7105"},
+    {url = "https://files.pythonhosted.org/packages/1d/77/6bc4ebcc95986ce57c74e94066f9a668b8508d32b0a07a427eb92b11e19f/duckdb-0.6.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c35ff4b1117096ef72d101524df0079da36c3735d52fcf1d907ccffa63bd6202"},
+    {url = "https://files.pythonhosted.org/packages/1e/5e/8b7472fdaedce2a3eed50da24335bfa81ca5dbca66d6b684a1646ab52727/duckdb-0.6.1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:35b01bc724e1933293f4c34f410d2833bfbb56d5743b515d805bbfed0651476e"},
+    {url = "https://files.pythonhosted.org/packages/1f/19/9c6f9a8b05335d60b590e7039dc7830a7c78e8e39d0b4b04d9e49de1e4ac/duckdb-0.6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:87b0d00eb9d1a7ebe437276203e0cdc93b4a2154ba9688c65e8d2a8735839ec6"},
+    {url = "https://files.pythonhosted.org/packages/21/e5/4d6832d593b29e4e16fca194fcabdb66f1cafb9dafee7d1439f742435999/duckdb-0.6.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:ce376966260eb5c351fcc6af627a979dbbcae3efeb2e70f85b23aa45a21e289d"},
+    {url = "https://files.pythonhosted.org/packages/2a/d8/aa2facdb198cab383221c5e13a7738f09830e3989908b02abd1cab682a0b/duckdb-0.6.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:4b280b2d8a01ecd4fe2feab041df70233c534fafbe33a38565b52c1e017529c7"},
+    {url = "https://files.pythonhosted.org/packages/2e/d7/0320924f9e817442afad06a5e428e8f5fb55b6cb20bfd2b0be4b3975ec08/duckdb-0.6.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:b4bbe2f6c1b109c626f9318eee80934ad2a5b81a51409c6b5083c6c5f9bdb125"},
+    {url = "https://files.pythonhosted.org/packages/30/b4/5f7f1d46392bbf0d95ebc53762b18228fd7331c7f9eebb72469469419672/duckdb-0.6.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e609a65b31c92f2f7166831f74b56f5ed54b33d8c2c4b4c3974c26fdc50464c5"},
+    {url = "https://files.pythonhosted.org/packages/31/5f/b80d14bd20e54915cec622b8bd1d6a36147e63bef93bad1487306242c806/duckdb-0.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:afa97d982dbe6b125631a17e222142e79bee88f7a13fc4cee92d09285e31ec83"},
+    {url = "https://files.pythonhosted.org/packages/35/53/d85036800c1672f15e178a623b2fcb3ac203664cbfa54180c39c74ad4102/duckdb-0.6.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:125ba45e8b08f28858f918ec9cbd3a19975e5d8d9e8275ef4ad924028a616e14"},
+    {url = "https://files.pythonhosted.org/packages/38/f8/257c3f72a2dcd7397492791baca7aaec15015ebd2b2d5780070ffb868f18/duckdb-0.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f4edcaa471d791393e37f63e3c7c728fa6324e3ac7e768b9dc2ea49065cd37cc"},
+    {url = "https://files.pythonhosted.org/packages/47/8d/140845f6f61f9fe936f5743fedb6625c0ff4781f3be928e4d3a20d551fc7/duckdb-0.6.1-cp310-cp310-win_amd64.whl", hash = "sha256:16fa96ffaa3d842a9355a633fb8bc092d119be08d4bc02013946d8594417bc14"},
+    {url = "https://files.pythonhosted.org/packages/48/80/0dee966cde56d2e1b3ea8e3389b2e93288d662bc0b85b6b0508f3151f3c0/duckdb-0.6.1.tar.gz", hash = "sha256:6d26e9f1afcb924a6057785e506810d48332d4764ddc4a5b414d0f2bf0cacfb4"},
+    {url = "https://files.pythonhosted.org/packages/55/d9/d80159f4304e351db0459a16e9c8d139c87a495300007cc105b75452c30f/duckdb-0.6.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:82cd30f5cf368658ef879b1c60276bc8650cf67cfe3dc3e3009438ba39251333"},
+    {url = "https://files.pythonhosted.org/packages/5c/ad/1186693bc6d73f5ba1ac4e13772ba57abfcc970aa03ccdfb8c7405b039f1/duckdb-0.6.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a782bbfb7f5e97d4a9c834c9e78f023fb8b3f6687c22ca99841e6ed944b724da"},
+    {url = "https://files.pythonhosted.org/packages/66/19/ca4d3bc96cc04361f917d1c25a45583326a341007741b57dddf6eb666f8a/duckdb-0.6.1-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5054792f22733f89d9cbbced2bafd8772d72d0fe77f159310221cefcf981c680"},
+    {url = "https://files.pythonhosted.org/packages/67/18/27d0b0b6d9cf1ecbe9d6abdd26e9788b10288ac20bd9426dcf2f39b1c299/duckdb-0.6.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:73c974b09dd08dff5e8bdedba11c7d0aa0fc46ca93954ee7d19e1e18c9883ac1"},
+    {url = "https://files.pythonhosted.org/packages/6c/78/06db249ac103d2fede9a2fd3c74571ea2ff96204fb67ecf1b569ad8fac27/duckdb-0.6.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:21cc503dffc2c68bb825e4eb3098e82f40e910b3d09e1b3b7f090d39ad53fbea"},
+    {url = "https://files.pythonhosted.org/packages/74/ad/271475c8b9c4bf42b4c59946eb9e1f1a0177966f02850804f62c4e81657d/duckdb-0.6.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e92dd6aad7e8c29d002947376b6f5ce28cae29eb3b6b58a64a46cdbfc5cb7943"},
+    {url = "https://files.pythonhosted.org/packages/78/cc/508a045cb18164d0890eb09f38bc7f8346aa03c387217c71aeeab1be61ec/duckdb-0.6.1-cp311-cp311-win_amd64.whl", hash = "sha256:93b074f473d68c944b0eeb2edcafd91ad11da8432b484836efaaab4e26351d48"},
+    {url = "https://files.pythonhosted.org/packages/79/a7/c01998a05ed41fd3bf124079de9508ee6002e5b120a4ba353817535eaa7a/duckdb-0.6.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cfea36b58928ce778d17280d4fb3bf0a2d7cff407667baedd69c5b41463ac0fd"},
+    {url = "https://files.pythonhosted.org/packages/7b/dd/3439c82a6bc61c677098ba0d1216665321d0624ef6d0e3bb2cc79c3c9616/duckdb-0.6.1-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7363ffe857d00216b659116647fbf1e925cb3895699015d4a4e50b746de13041"},
+    {url = "https://files.pythonhosted.org/packages/7f/fa/d79b39cec15fd227c7174108f24541bd69fc7f1751ec2cf02099055e2592/duckdb-0.6.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:143611bd1b7c13343f087d4d423a7a8a4f33a114c5326171e867febf3f0fcfe1"},
+    {url = "https://files.pythonhosted.org/packages/84/8f/72a0be1eb246471b58162eb319ac003ac5ac09a47aec72755a91743d3954/duckdb-0.6.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06c1cef25f896b2284ba048108f645c72fab5c54aa5a6f62f95663f44ff8a79b"},
+    {url = "https://files.pythonhosted.org/packages/8a/54/4210ce0b26a010fd2755f8d78dcaeceeb4d1ddda76d2e884c0b130fae6dc/duckdb-0.6.1-cp311-cp311-win32.whl", hash = "sha256:e3702d4a9ade54c6403f6615a98bbec2020a76a60f5db7fcf085df1bd270e66e"},
+    {url = "https://files.pythonhosted.org/packages/8d/3d/2c5e19de3eb44213cb860d095e597eaa0e264ce34c918bb8a239b3b2c03d/duckdb-0.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:00b7be8f67ec1a8edaa8844f521267baa1a795f4c482bfad56c72c26e1862ab2"},
+    {url = "https://files.pythonhosted.org/packages/92/7c/5879a645e7a3abc13781c368a0ca550fe64e049f5c2e73b8d5834bb2a010/duckdb-0.6.1-cp39-cp39-win32.whl", hash = "sha256:d9212d76e90b8469743924a4d22bef845be310d0d193d54ae17d9ef1f753cfa7"},
+    {url = "https://files.pythonhosted.org/packages/94/68/c633dcd576dd63e627619a6274c17b6ddc8e2637fa9b037a5241b687c40b/duckdb-0.6.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e566514f9327f89264e98ac14ee7a84fbd9857328028258422c3e8375ee19d25"},
+    {url = "https://files.pythonhosted.org/packages/98/74/069f636ba410c7055847cd202bb8fb7e8ea1b0e0a2ae6b131ba40e0d4322/duckdb-0.6.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:998165b2fb1f1d2b0ad742096015ea70878f7d40304643c7424c3ed3ddf07bfc"},
+    {url = "https://files.pythonhosted.org/packages/9a/ce/39e5f2907cd4b7ae988a2b4a36c7c7d5cf6047e8e91299646a03cf5260da/duckdb-0.6.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:54b3da77ad893e99c073087ff7f75a8c98154ac5139d317149f12b74367211db"},
+    {url = "https://files.pythonhosted.org/packages/9f/98/42987cc5a2b64c217ce377c651c47510a3fab48752ea3706ec9580401976/duckdb-0.6.1-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8b544dd04bb851d08bc68b317a7683cec6091547ae75555d075f8c8a7edb626e"},
+    {url = "https://files.pythonhosted.org/packages/a2/02/a36ca6545c81cb6ec339fcff178b931b0079cdd9d39806da2d440dcdab32/duckdb-0.6.1-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3941b3a1e8a1cdb7b90ab3917b87af816e71f9692e5ada7f19b6b60969f731e5"},
+    {url = "https://files.pythonhosted.org/packages/b6/ae/ea1b6860227f0bb175d8a331a235c66a24883c746ee308a9391c5e697613/duckdb-0.6.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:99a7172563a3ae67d867572ce27cf3962f58e76f491cb7f602f08c2af39213b3"},
+    {url = "https://files.pythonhosted.org/packages/b9/ee/4016c31834123716532c97cb6a180f35ba90f63bfbae30a1af3a861b0929/duckdb-0.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8442e074de6e1969c3d2b24363a5a6d7f866d5ac3f4e358e357495b389eff6c1"},
+    {url = "https://files.pythonhosted.org/packages/bc/1b/a0b13a6e985ff1024e0d52b372f43e385ce1538773ecac250e82543572e2/duckdb-0.6.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b64eb53d0d0695814bf1b65c0f91ab7ed66b515f89c88038f65ad5e0762571c"},
+    {url = "https://files.pythonhosted.org/packages/c3/a5/3a363fb6c1a7d3e35241ef66d69fc8a63f2110e3fdbf11f38ae0d0d5fa58/duckdb-0.6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:adae183924d6d479202c39072e37d440b511326e84525bcb7432bca85f86caba"},
+    {url = "https://files.pythonhosted.org/packages/c5/ef/ff74822cbd8792138edad7da762fc1d371723761fe9362a44df85b09774c/duckdb-0.6.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b31c2883de5b19591a2852165e6b3f9821f77af649835f27bc146b26e4aa30cb"},
+    {url = "https://files.pythonhosted.org/packages/c9/76/e20ce03799d0734cef94cbaea7e501e3dd9931e352f096db285bbffd18df/duckdb-0.6.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0925778200090d3d5d8b6bb42b4d05d24db1e8912484ba3b7e7b7f8569f17dcb"},
+    {url = "https://files.pythonhosted.org/packages/de/b1/7f2ee1e567de4826f019c0aabec4aee9f1a876dbc837b4c27b783dfbff19/duckdb-0.6.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f2c37d5a0391cf3a3a66e63215968ffb78e6b84f659529fa4bd10478f6203071"},
+    {url = "https://files.pythonhosted.org/packages/e6/2d/b43e5864efde07dce1d20a07cf2a238efb71878e002a14b0234da4a60936/duckdb-0.6.1-cp310-cp310-win32.whl", hash = "sha256:b39045074fb9a3f068496475a5d627ad4fa572fa3b4980e3b479c11d0b706f2d"},
+    {url = "https://files.pythonhosted.org/packages/e9/11/9072cfe234ca3b750e8d6a2b40147b8e2eff15382e398adda007f613829a/duckdb-0.6.1-cp38-cp38-win32.whl", hash = "sha256:bfe39ed3a03e8b1ed764f58f513b37b24afe110d245803a41655d16d391ad9f1"},
+    {url = "https://files.pythonhosted.org/packages/ef/a0/42dc092e852b3fc577445a53119d954d5b0c50815782b91a0cc66af4a1a1/duckdb-0.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:5c54910fbb6de0f21d562e18a5c91540c19876db61b862fc9ffc8e31be8b3f03"},
+    {url = "https://files.pythonhosted.org/packages/f5/5b/36689e4cacd753b68b2cac9a98496300be3d6eaf9fc4f93e4b4c38ad750b/duckdb-0.6.1-cp37-cp37m-win32.whl", hash = "sha256:f1d709aa6a26172a3eab804b57763d5cdc1a4b785ac1fc2b09568578e52032ee"},
+    {url = "https://files.pythonhosted.org/packages/ff/47/936e3be2d10c3b90346ef14eff4a076bb41974143202a086786fd8aa7328/duckdb-0.6.1-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a6bf2ae7bec803352dade14561cb0b461b2422e70f75d9f09b36ba2dad2613b"},
 ]
 "dynaconf 3.1.11" = [
     {url = "https://files.pythonhosted.org/packages/54/6f/09c3ca2943314e0cae5cb2eeca1b77f5968855e13d6fdaae32c8e055eb7c/dynaconf-3.1.11.tar.gz", hash = "sha256:d9cfb50fd4a71a543fd23845d4f585b620b6ff6d9d3cc1825c614f7b2097cb39"},
@@ -411,6 +474,36 @@ content_hash = "sha256:b18a02087d809a43d22ca292504dbd8cf6934f1c9c5406f10b247ea87
 "idna 3.4" = [
     {url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
     {url = "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
+]
+"numpy 1.23.5" = [
+    {url = "https://files.pythonhosted.org/packages/08/36/6589c7d5fc4fecda63de4453fefff7c58f6de2b1bb7dfbe7fa807bf85c46/numpy-1.23.5-cp39-cp39-win_amd64.whl", hash = "sha256:09b7847f7e83ca37c6e627682f145856de331049013853f344f37b0c9690e3df"},
+    {url = "https://files.pythonhosted.org/packages/0f/3d/25e99f2191cce5029310c41cf9a34b5107d4475477bbce2f6d2e68c1c93b/numpy-1.23.5-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9a909a8bae284d46bbfdefbdd4a262ba19d3bc9921b1e76126b1d21c3c34135"},
+    {url = "https://files.pythonhosted.org/packages/0f/ae/dad4b8e7c65494cbbd1c063de114efaf9acd0f5f6171f044f0d4b6299787/numpy-1.23.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9c88793f78fca17da0145455f0d7826bcb9f37da4764af27ac945488116efe63"},
+    {url = "https://files.pythonhosted.org/packages/19/0d/b8c34e4baf258d77a8592bdce45183e9a12874c167f5966c7dd467b74ea9/numpy-1.23.5-cp311-cp311-win_amd64.whl", hash = "sha256:0cbe9848fad08baf71de1a39e12d1b6310f1d5b2d0ea4de051058e6e1076852d"},
+    {url = "https://files.pythonhosted.org/packages/25/7b/3b587a62aa54ad7ecf90eabfc77cf78e96d3df1d0e8c31fc534ad3ca6e17/numpy-1.23.5-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:abdde9f795cf292fb9651ed48185503a2ff29be87770c3b8e2a14b0cd7aa16f8"},
+    {url = "https://files.pythonhosted.org/packages/2b/1a/9ac00116d3a64b5ea031fdb2ff071062a6e2140553fa0770b5f007b84252/numpy-1.23.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5039f55555e1eab31124a5768898c9e22c25a65c1e0037f4d7c495a45778c9f2"},
+    {url = "https://files.pythonhosted.org/packages/3f/ce/04d7772671d8d3a14e426d7560047821c4e2d29ee2b5cfa252601412083b/numpy-1.23.5-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:01dd17cbb340bf0fc23981e52e1d18a9d4050792e8fb8363cecbf066a84b827d"},
+    {url = "https://files.pythonhosted.org/packages/42/38/775b43da55fa7473015eddc9a819571517d9a271a9f8134f68fb9be2f212/numpy-1.23.5.tar.gz", hash = "sha256:1b1766d6f397c18153d40015ddfc79ddb715cabadc04d2d228d4e5a8bc4ded1a"},
+    {url = "https://files.pythonhosted.org/packages/4c/42/6274f92514fbefcb1caa66d56d82ac7ac89f7652c0cef1e159a4b79e09f1/numpy-1.23.5-cp38-cp38-win_amd64.whl", hash = "sha256:ca51fcfcc5f9354c45f400059e88bc09215fb71a48d3768fb80e357f3b457e1e"},
+    {url = "https://files.pythonhosted.org/packages/4c/b9/038abd6fbd67b05b03cb1af590cfc02b7f1e5a37af7ac6a868f5093c29f5/numpy-1.23.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33161613d2269025873025b33e879825ec7b1d831317e68f4f2f0f84ed14c719"},
+    {url = "https://files.pythonhosted.org/packages/4d/39/d33202cc56c21123a50c6d5e160d00c18ff685ab864dbd4bf80dd40a7af9/numpy-1.23.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e9f4c4e51567b616be64e05d517c79a8a22f3606499941d97bb76f2ca59f982d"},
+    {url = "https://files.pythonhosted.org/packages/5d/a1/cdac656aed8bc04dc86296490f8dbef68474c3294cc31af30f2bd0ec06de/numpy-1.23.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf837dc63ba5c06dc8797c398db1e223a466c7ece27a1f7b5232ba3466aafe3d"},
+    {url = "https://files.pythonhosted.org/packages/63/d4/3f0d610a2006434f2b7b2e0c80291368d59b0a03bb3e1911fdb9476232d4/numpy-1.23.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0aaee12d8883552fadfc41e96b4c82ee7d794949e2a7c3b3a7201e968c7ecab9"},
+    {url = "https://files.pythonhosted.org/packages/67/6b/d7c93d458d16464da9b3f560a20c363a19e242ebbb019bd1e1d797523851/numpy-1.23.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7903ba8ab592b82014713c491f6c5d3a1cde5b4a3bf116404e08f5b52f6daf43"},
+    {url = "https://files.pythonhosted.org/packages/6a/03/ae6c3c307f9c5c7516de3df3e764ebb1de33e54e197f0370992138433ef4/numpy-1.23.5-cp310-cp310-win_amd64.whl", hash = "sha256:dbee87b469018961d1ad79b1a5d50c0ae850000b639bcb1b694e9981083243b6"},
+    {url = "https://files.pythonhosted.org/packages/6e/7f/94797cfe0263a30805f3074e535adfde02b885ac43d1e4dac85f82213b0b/numpy-1.23.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ce571367b6dfe60af04e04a1834ca2dc5f46004ac1cc756fb95319f64c095a96"},
+    {url = "https://files.pythonhosted.org/packages/8c/7a/171d3b4a54de835c8f95181dd2885607c0e04adca55ef99d9de559b4c9ba/numpy-1.23.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8969bfd28e85c81f3f94eb4a66bc2cf1dbdc5c18efc320af34bffc54d6b1e38f"},
+    {url = "https://files.pythonhosted.org/packages/9b/55/a2669debe264b1f22a8133734595128e40b96a8066e17e53e8d160168e41/numpy-1.23.5-cp311-cp311-win32.whl", hash = "sha256:b2a9ab7c279c91974f756c84c365a669a887efa287365a8e2c418f8b3ba73fb0"},
+    {url = "https://files.pythonhosted.org/packages/9e/9d/ff17c357f7144301da85f8c03d56593cfd2904e9ce89f86c8eefaa96d2d5/numpy-1.23.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a7ac231a08bb37f852849bbb387a20a57574a97cfc7b6cabb488a4fc8be176de"},
+    {url = "https://files.pythonhosted.org/packages/af/92/8efba008b9bda66456a1844a0e133dc76c08c5fb68c67a674f046211db29/numpy-1.23.5-cp310-cp310-win32.whl", hash = "sha256:522e26bbf6377e4d76403826ed689c295b0b238f46c28a7251ab94716da0b280"},
+    {url = "https://files.pythonhosted.org/packages/b8/d0/e6a2cb9a3f3e863a43e50949e9ae704be70baf398fd5af59355f65c8740a/numpy-1.23.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:56e454c7833e94ec9769fa0f86e6ff8e42ee38ce0ce1fa4cbb747ea7e06d56aa"},
+    {url = "https://files.pythonhosted.org/packages/b9/0e/10ab011eaebeed29d28ad710d0a3ab2654c06a2800e178e8f2f3a5947ad4/numpy-1.23.5-cp38-cp38-win32.whl", hash = "sha256:06005a2ef6014e9956c09ba07654f9837d9e26696a0470e42beedadb78c11b07"},
+    {url = "https://files.pythonhosted.org/packages/bf/d1/1017fe3f5d65c4fe054a793f18f940d913868bb2846a02d3f6244a829a30/numpy-1.23.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:92c8c1e89a1f5028a4c6d9e3ccbe311b6ba53694811269b992c0b224269e2398"},
+    {url = "https://files.pythonhosted.org/packages/c6/4f/63f6f16d3f44a764a3b66c6233e133baf912e198a93e14c39ee991f587d0/numpy-1.23.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d208a0f8729f3fb790ed18a003f3a57895b989b40ea4dce4717e9cf4af62c6bb"},
+    {url = "https://files.pythonhosted.org/packages/d2/55/b9b4bfb9d1d828d7d3192c4059e7b4a7d755ba2e1618089af4be77c152d1/numpy-1.23.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f063b69b090c9d918f9df0a12116029e274daf0181df392839661c4c7ec9018a"},
+    {url = "https://files.pythonhosted.org/packages/d5/95/f311e6fdaabe24f909eeb6d5482e3adef27fa8389cb8a84823ae560bf480/numpy-1.23.5-cp39-cp39-win32.whl", hash = "sha256:af1da88f6bc3d2338ebbf0e22fe487821ea4d8e89053e25fa59d1d79786e7481"},
+    {url = "https://files.pythonhosted.org/packages/e4/f3/679b3a042a127de0d7c84874913c3e23bb84646eb3bc6ecab3f8c872edc9/numpy-1.23.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e05b1c973a9f858c74367553e236f287e749465f773328c8ef31abe18f691e1"},
+    {url = "https://files.pythonhosted.org/packages/e8/ad/b935c7421657a032fd2a5332eed098f3b9993a155afceb1daa280ff6611f/numpy-1.23.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58f545efd1108e647604a1b5aa809591ccd2540f468a880bedb97247e72db387"},
 ]
 "psycopg2 2.9.5" = [
     {url = "https://files.pythonhosted.org/packages/04/51/00ed720de223485a56c28b404747b96806679e720f4c97a75bdd556a01f4/psycopg2-2.9.5-cp310-cp310-win32.whl", hash = "sha256:d3ef67e630b0de0779c42912fe2cbae3805ebaba30cda27fea2a3de650a9414f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "dynaconf>=3.1.11",
     "pyjq>=2.6.0",
     "rich>=12.6.0",
+    "duckdb>=0.6.1",
 ]
 requires-python = ">=3.10"
 readme = "README.md"

--- a/recap/search/__init__.py
+++ b/recap/search/__init__.py
@@ -1,7 +1,8 @@
-from recap.search import jq, recap
+from recap.search import jq, recap, duckdb
 
 
 registry = {
+    'duckdb': duckdb,
     'jq': jq,
     'recap': recap,
 }

--- a/recap/search/duckdb.py
+++ b/recap/search/duckdb.py
@@ -1,0 +1,113 @@
+import duckdb
+import json
+from .abstract import AbstractSearch, AbstractIndexer
+from contextlib import contextmanager
+from pathlib import PurePosixPath
+from typing import List, Any, Generator
+from urllib.parse import urlparse
+
+
+class DuckDbSearch(AbstractSearch):
+    def __init__(
+        self,
+        connection: duckdb.DuckDBPyConnection,
+    ):
+        self.connection = connection
+        # TODO should try this and catch if read_only=True
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS catalog "
+            "(path VARCHAR, metadata JSON)"
+        )
+
+    def search(self, query: str) -> List[dict[str, Any]]:
+        results = []
+
+        self.connection.execute(
+            # ZOMG SQL injection. Should figure out a better way to do this.
+            f"SELECT metadata FROM catalog WHERE {query}"
+        )
+
+        for row in self.connection.fetchall():
+            results.append(json.loads(row[0]))
+
+        return results
+
+
+class DuckDbIndexer(AbstractIndexer):
+    def __init__(
+        self,
+        connection: duckdb.DuckDBPyConnection,
+    ):
+        self.connection = connection
+        self.connection.execute(
+            "CREATE TABLE IF NOT EXISTS catalog "
+            "(path VARCHAR, metadata JSON)"
+        )
+
+    def written(
+        self,
+        path: PurePosixPath,
+        type: str,
+        metadata: Any,
+    ):
+        # TODO An UPSERT would be great here. Doesn't seem DuckDB supports it.
+        self.connection.begin()
+        doc = self._get_metadata(path)
+        new_doc = len(doc) == 0
+        doc[type] = metadata
+
+        if new_doc:
+            self.connection.execute(
+                "INSERT INTO catalog VALUES (?, ?)",
+                [str(path), json.dumps(doc)]
+            )
+        else:
+            self.connection.execute(
+                "UPDATE catalog SET metadata = ? WHERE path = ?",
+                [json.dumps(doc), str(path)]
+            )
+
+        self.connection.commit()
+
+    def removed(
+        self,
+        path: PurePosixPath,
+        type: str | None = None,
+    ):
+        if not type:
+            self.connection.execute(
+                "DELETE FROM catalog WHERE path=?",
+                [str(path)]
+            )
+        else:
+            self.connection.begin()
+            doc = self._get_metadata(path)
+            doc.pop(type, None)
+            self.connection.execute(
+                "UPDATE catalog SET metadata = ? WHERE path = ?",
+                [json.dumps(doc), str(path)]
+            )
+            self.connection.commit()
+
+    def _get_metadata(self, path: PurePosixPath) -> Any:
+        self.connection.execute(
+            "SELECT metadata FROM catalog WHERE path = ?", [str(path)]
+        )
+        maybe_row = self.connection.fetchone()
+        return json.loads(maybe_row[0]) if maybe_row else {} # pyright: ignore [reportGeneralTypeIssues]
+
+@contextmanager
+def open_search(**config) -> Generator[DuckDbSearch, None, None]:
+    url = urlparse(config['url'])
+    read_only = config.get('read_only', False)
+    duckdb_options = config.get('duckdb', {})
+    with duckdb.connect(url.path, read_only=read_only, **duckdb_options) as c:
+        yield DuckDbSearch(c)
+
+
+@contextmanager
+def open_indexer(**config) -> Generator[DuckDbIndexer, None, None]:
+    url = urlparse(config['url'])
+    duckdb_options = config.get('duckdb', {})
+    with duckdb.connect(url.path, **duckdb_options) as c:
+        yield DuckDbIndexer(c)


### PR DESCRIPTION
Users can now use DuckDB to index and search metadata. The indexer uses a single table, `catalog`, which has two fields: `path` and `metadata`. The `metadata` field is a `JSON` type of dictionary, which contains types (column, location, etc) for keys, and JSON objects as values.

Search is implemented in a hacky way right now. Queryes are just appeneded to `SELECT metadata FROM catalog WHERE `, which means injection attacks are possible. Users supply where clauses using the standard `recap search` command, like so:

    recap search "metadata->'$.location'->>'$.table' = 'my_table_name'"

Config for DuckDB looks like this:

```
[search]
type = "duckdb"
url = "file:///tmp/recap.db"
```

And off you go.