### PR TITLE
Add included SQLAlchemy DBs to crawler registry

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -182,6 +182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "65.6.3"
+requires_python = ">=3.7"
+summary = "Easily download, build, install, upgrade, and uninstall Python packages"
+
+[[package]]
 name = "sniffio"
 version = "1.3.0"
 requires_python = ">=3.7"
@@ -203,6 +209,7 @@ requires_python = ">=3.7"
 summary = "The little ASGI library that shines."
 dependencies = [
     "anyio<5,>=3.4.0",
+    "typing-extensions>=3.10.0; python_version < \"3.10\"",
 ]
 
 [[package]]
@@ -270,7 +277,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:4f890e95dba6a21ae762d6dc4f2a8066cff44adf8ca4339730c25ad32cc44b18"
+content_hash = "sha256:fab2920bd9ddff07a89765b10ce3d88ef39b28dc5cdb727bae47681877b75aba"
 
 [metadata.files]
 "anyio 3.6.2" = [
@@ -619,6 +626,10 @@ content_hash = "sha256:4f890e95dba6a21ae762d6dc4f2a8066cff44adf8ca4339730c25ad32
 "rich 12.6.0" = [
     {url = "https://files.pythonhosted.org/packages/11/23/814edf09ec6470d52022b9e95c23c1bef77f0bc451761e1504ebd09606d3/rich-12.6.0.tar.gz", hash = "sha256:ba3a3775974105c221d31141f2c116f4fd65c5ceb0698657a11e9f295ec93fd0"},
     {url = "https://files.pythonhosted.org/packages/32/60/81ac2e7d1e3b861ab478a72e3b20fc91c4302acd2274822e493758941829/rich-12.6.0-py3-none-any.whl", hash = "sha256:a4eb26484f2c82589bd9a17c73d32a010b1e29d89f1604cd9bf3a2097b81bb5e"},
+]
+"setuptools 65.6.3" = [
+    {url = "https://files.pythonhosted.org/packages/b6/21/cb9a8d0b2c8597c83fce8e9c02884bce3d4951e41e807fc35791c6b23d9a/setuptools-65.6.3.tar.gz", hash = "sha256:a7620757bf984b58deaf32fc8a4577a9bbc0850cf92c20e1ce41c38c19e5fb75"},
+    {url = "https://files.pythonhosted.org/packages/ef/e3/29d6e1a07e8d90ace4a522d9689d03e833b67b50d1588e693eec15f26251/setuptools-65.6.3-py3-none-any.whl", hash = "sha256:57f6f22bde4e042978bcd50176fdb381d7c21a9efa4041202288d3737a0c6a54"},
 ]
 "sniffio 1.3.0" = [
     {url = "https://files.pythonhosted.org/packages/c3/a0/5dba8ed157b0136607c7f2151db695885606968d1fae123dc3391e0cfdbf/sniffio-1.3.0-py3-none-any.whl", hash = "sha256:eecefdce1e5bbfb7ad2eeaabf7c1eeb404d7757c379bd1f7e5cce9d8bf425384"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,15 +11,15 @@ dependencies = [
     "fsspec>=2022.11.0",
     "httpx>=0.23.1",
     "typer>=0.7.0",
-    # TODO should we move this into recap[db] or something?
     "psycopg2>=2.9.5",
     "sqlalchemy>=1.4.45",
     "dynaconf>=3.1.11",
     "pyjq>=2.6.0",
     "rich>=12.6.0",
     "duckdb>=0.6.1",
+    "setuptools>=65.6.3",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "MIT"}
 

--- a/recap/crawlers/__init__.py
+++ b/recap/crawlers/__init__.py
@@ -6,8 +6,12 @@ from urllib.parse import urlparse
 
 
 registry = {
+    # These are the included SQLAlchemy dialects
+    'mssql': db,
+    'mysql': db,
+    'oracle': db,
     'postgresql': db,
-    # TODO add other DB schemes here
+    'sqlite': db,
 }
 
 
@@ -18,7 +22,9 @@ def open(
     storage: AbstractStorage, **config
 ):
     url = urlparse(config['url'])
-    return registry[url.scheme].open(
+    # Handle schemes like "postgresql+psycopg2"
+    scheme_prefix = url.scheme.split('+')[0]
+    return registry[scheme_prefix].open(
         infra,
         instance,
         storage,


### PR DESCRIPTION
I've added all of the included DB dialect schemes in SQLAlchemy. I also added support for different drivers in theh scheme (e.g. `postgresql+psycopg2://` or `mysql+pymysql`).

Note that users will still need to `pip3 install` the drivers for the DB of their choice. In development, I'm using:

    pip3 install psycopg2

I also added setuptools to the dependency list since dynaconf appears to require it.