### PR TITLE
Import storage, search, and crawler modules with importlib

### DIFF
--- a/recap/crawlers/__init__.py
+++ b/recap/crawlers/__init__.py
@@ -1,18 +1,7 @@
-from contextlib import contextmanager
-from recap.crawlers import db
+import importlib
+# TODO When I create an AbstractCrawler, use it here
+from recap.crawlers.db import Crawler
 from recap.storage.abstract import AbstractStorage
-from typing import Generator
-from urllib.parse import urlparse
-
-
-registry = {
-    # These are the included SQLAlchemy dialects
-    'mssql': db,
-    'mysql': db,
-    'oracle': db,
-    'postgresql': db,
-    'sqlite': db,
-}
 
 
 # TODO should type the return
@@ -20,11 +9,10 @@ def open(
     infra: str,
     instance: str,
     storage: AbstractStorage, **config
-):
-    url = urlparse(config['url'])
-    # Handle schemes like "postgresql+psycopg2"
-    scheme_prefix = url.scheme.split('+')[0]
-    return registry[scheme_prefix].open(
+) -> Crawler:
+    module_name = config['module']
+    module = importlib.import_module(module_name)
+    return module.open(
         infra,
         instance,
         storage,

--- a/recap/crawlers/db.py
+++ b/recap/crawlers/db.py
@@ -31,6 +31,7 @@ class Metadata:
     # TODO get indexes and foreign keys and stuff
 
 
+# TODO We need an AbstractCrawler that DbCrawler inherits from.
 class Crawler:
     def __init__(
         self,

--- a/recap/search/__init__.py
+++ b/recap/search/__init__.py
@@ -1,19 +1,13 @@
-from recap.search import jq, recap, duckdb
-
-
-registry = {
-    'duckdb': duckdb,
-    'jq': jq,
-    'recap': recap,
-}
-
+import importlib
+from .abstract import AbstractIndexer, AbstractSearch
 
 # TODO Two different open methods feels hacky.
-# TODO should type the return
-def open_search(**config):
-    backend = config['type']
-    return registry[backend].open_search(**config)
+def open_search(**config) -> AbstractSearch:
+    module_name = config['module']
+    module = importlib.import_module(module_name)
+    return module.open_search(**config)
 
-def open_indexer(**config):
-    backend = config['type']
-    return registry[backend].open_indexer(**config)
+def open_indexer(**config) -> AbstractIndexer:
+    module_name = config['module']
+    module = importlib.import_module(module_name)
+    return module.open_indexer(**config)

--- a/recap/storage/__init__.py
+++ b/recap/storage/__init__.py
@@ -1,15 +1,7 @@
-from recap.storage import fs, recap
-from urllib.parse import urlparse
+import importlib
+from .abstract import AbstractStorage
 
-
-registry = {
-    'http': recap,
-    'file': fs,
-    's3': fs,
-}
-
-
-# TODO should type the return
-def open(**config):
-    url = urlparse(config['url'])
-    return registry[url.scheme].open(**config)
+def open(**config) -> AbstractStorage:
+    module_name = config['module']
+    module = importlib.import_module(module_name)
+    return module.open(**config)


### PR DESCRIPTION
I'm switching from a hard-coded registry to dynamic imports for the storage, search, and crawler layer. This will allow users to define whatever backends hey like, so long as the backends provide an appropriate open() method.

I noticed that the crawler layer needs an AbstractCrawler. Right now, the only implementation is a DbCrawler. When I  create an FsCrawler, I'll update the `crawlers.__init__.open` method to return AbstractCrawler.