### PR TITLE
Create `jq` and `duckdb` optional dependencies

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -277,7 +277,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:fab2920bd9ddff07a89765b10ce3d88ef39b28dc5cdb727bae47681877b75aba"
+content_hash = "sha256:b2a893ceda699ed8783b6ea06abad3e19092393743f8a457869871823dbe81ac"
 
 [metadata.files]
 "anyio 3.6.2" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,7 @@ dependencies = [
     "psycopg2>=2.9.5",
     "sqlalchemy>=1.4.45",
     "dynaconf>=3.1.11",
-    "pyjq>=2.6.0",
     "rich>=12.6.0",
-    "duckdb>=0.6.1",
     "setuptools>=65.6.3",
 ]
 requires-python = ">=3.9"
@@ -25,6 +23,15 @@ license = {text = "MIT"}
 
 [project.scripts]
 recap = "recap.cli:app"
+
+[project.optional-dependencies]
+duckdb = [
+    "duckdb>=0.6.1",
+]
+jq = [
+    "pyjq>=2.6.0",
+]
+all = ["recap[duckdb,jq]"]
 
 [build-system]
 requires = ["pdm-pep517>=1.0.0"]


### PR DESCRIPTION
The search dependencies are a bit heavier and more finicky to compile. I'm moving them into separate optional dependencies (`recap[jq]` and `recap[duckdb]`). Users will need to `pip3 install` one of these packages to use search.