### PR TITLE
Combine `AbstractSearch` and `AbstractIndexer`

### DIFF
--- a/recap/api.py
+++ b/recap/api.py
@@ -1,6 +1,6 @@
 from .config import settings
 from . import storage, search
-from .search.abstract import AbstractSearch
+from .search.abstract import AbstractSearchIndex
 from .storage.abstract import AbstractStorage
 from .storage.notifier import StorageNotifier
 from fastapi import Body, Depends, FastAPI
@@ -11,14 +11,14 @@ from typing import Any, List, Generator
 app = FastAPI()
 
 
-def get_search() -> Generator[AbstractSearch, None, None]:
-    with search.open_search(**settings['search']) as s:
+def get_search() -> Generator[AbstractSearchIndex, None, None]:
+    with search.open(**settings['search']) as s:
         yield s
 
 
 def get_storage() -> Generator[AbstractStorage, None, None]:
     with storage.open(**settings['storage']) as st:
-        with search.open_indexer(**settings['search']) as se:
+        with search.open(**settings['search']) as se:
             yield StorageNotifier(st, se)
 
 
@@ -26,7 +26,7 @@ def get_storage() -> Generator[AbstractStorage, None, None]:
 @app.get("/search")
 def query_search(
     query: str,
-    search: AbstractSearch = Depends(get_search),
+    search: AbstractSearchIndex = Depends(get_search),
 ) -> List[dict[str, Any]]:
     return search.search(query)
 

--- a/recap/cli.py
+++ b/recap/cli.py
@@ -26,7 +26,7 @@ def crawler():
     from .storage.notifier import StorageNotifier
 
     with storage.open(**settings['storage']) as s:
-        with search.open_indexer(**settings['search']) as i:
+        with search.open(**settings['search']) as i:
             for infra, instance_dict in settings['crawlers'].items():
                 for instance, instance_config in instance_dict.items():
                     wrapped_storage = StorageNotifier(s, i)
@@ -40,7 +40,7 @@ def crawler():
 
 @app.command()
 def search(query: str):
-    with search_module.open_search(**settings['search']) as s:
+    with search_module.open(**settings['search']) as s:
         results = s.search(query)
         print_json(data=results)
 

--- a/recap/crawlers/__init__.py
+++ b/recap/crawlers/__init__.py
@@ -1,20 +1,22 @@
 import importlib
 # TODO When I create an AbstractCrawler, use it here
+from contextlib import contextmanager
 from recap.crawlers.db import Crawler
 from recap.storage.abstract import AbstractStorage
+from typing import Generator
 
-
-# TODO should type the return
+@contextmanager
 def open(
     infra: str,
     instance: str,
     storage: AbstractStorage, **config
-) -> Crawler:
+) -> Generator[Crawler, None, None]:
     module_name = config['module']
     module = importlib.import_module(module_name)
-    return module.open(
+    with module.open(
         infra,
         instance,
         storage,
         **config
-    )
+    ) as c:
+        yield c

--- a/recap/search/__init__.py
+++ b/recap/search/__init__.py
@@ -1,13 +1,12 @@
 import importlib
-from .abstract import AbstractIndexer, AbstractSearch
+from .abstract import AbstractSearchIndex
+from contextlib import contextmanager
+from typing import Generator
 
-# TODO Two different open methods feels hacky.
-def open_search(**config) -> AbstractSearch:
+
+@contextmanager
+def open(**config) -> Generator[AbstractSearchIndex, None, None]:
     module_name = config['module']
     module = importlib.import_module(module_name)
-    return module.open_search(**config)
-
-def open_indexer(**config) -> AbstractIndexer:
-    module_name = config['module']
-    module = importlib.import_module(module_name)
-    return module.open_indexer(**config)
+    with module.open(**config) as s:
+        yield s

--- a/recap/search/abstract.py
+++ b/recap/search/abstract.py
@@ -3,7 +3,7 @@ from pathlib import PurePosixPath
 from typing import List, Any
 
 
-class AbstractSearch(ABC):
+class AbstractSearchIndex(ABC):
     @abstractmethod
     def search(
         self,
@@ -11,8 +11,6 @@ class AbstractSearch(ABC):
     ) -> List[dict[str, Any]]:
         raise NotImplementedError
 
-
-class AbstractIndexer(ABC):
     @abstractmethod
     def written(
         self,

--- a/recap/search/jq.py
+++ b/recap/search/jq.py
@@ -1,6 +1,6 @@
 import fsspec
 import pyjq
-from .abstract import AbstractSearch, AbstractIndexer
+from .abstract import AbstractSearchIndex
 from contextlib import contextmanager
 from pathlib import PurePosixPath
 from recap.storage.fs import FilesystemStorage
@@ -8,7 +8,7 @@ from typing import List, Any, Generator
 from urllib.parse import urlparse
 
 
-class JqSearch(AbstractSearch):
+class JqSearchIndex(AbstractSearchIndex):
     def __init__(
         self,
         path: PurePosixPath,
@@ -35,8 +35,6 @@ class JqSearch(AbstractSearch):
 
         return results
 
-
-class JqIndexer(AbstractIndexer):
     def written(
         self,
         path: PurePosixPath,
@@ -54,7 +52,7 @@ class JqIndexer(AbstractIndexer):
 
 
 @contextmanager
-def open_search(**config) -> Generator[JqSearch, None, None]:
+def open(**config) -> Generator[JqSearchIndex, None, None]:
     url = urlparse(config['url'])
     fs_options = config.get('fs', {})
     fs = fsspec.filesystem(
@@ -62,12 +60,7 @@ def open_search(**config) -> Generator[JqSearch, None, None]:
         **fs_options,
         # TODO This should move to the filesystem storage config
         auto_mkdir=True)
-    yield JqSearch(
+    yield JqSearchIndex(
         PurePosixPath(url.path),
         fs,
     )
-
-
-@contextmanager
-def open_indexer(**config) -> Generator[JqIndexer, None, None]:
-    yield JqIndexer()

--- a/recap/search/recap.py
+++ b/recap/search/recap.py
@@ -1,11 +1,11 @@
 import httpx
-from .abstract import AbstractSearch, AbstractIndexer
+from .abstract import AbstractSearchIndex
 from contextlib import contextmanager
 from pathlib import PurePosixPath
 from typing import Any, List, Generator
 
 
-class RecapSearch(AbstractSearch):
+class RecapSearchIndex(AbstractSearchIndex):
     def __init__(
         self,
         client: httpx.Client,
@@ -18,8 +18,6 @@ class RecapSearch(AbstractSearch):
     ) -> List[dict[str, Any]]:
         return self.client.get('/search', params={'query': query}).json()
 
-
-class RecapIndexer(AbstractIndexer):
     def written(
         self,
         path: PurePosixPath,
@@ -37,11 +35,6 @@ class RecapIndexer(AbstractIndexer):
 
 
 @contextmanager
-def open_search(**config) -> Generator[RecapSearch, None, None]:
+def open(**config) -> Generator[RecapSearchIndex, None, None]:
     with httpx.Client(base_url=config['url']) as client:
-        yield RecapSearch(client)
-
-
-@contextmanager
-def open_indexer(**config) -> Generator[RecapIndexer, None, None]:
-    yield RecapIndexer()
+        yield RecapSearchIndex(client)

--- a/recap/storage/__init__.py
+++ b/recap/storage/__init__.py
@@ -1,7 +1,12 @@
 import importlib
 from .abstract import AbstractStorage
+from contextlib import contextmanager
+from typing import Generator
 
-def open(**config) -> AbstractStorage:
+
+@contextmanager
+def open(**config) -> Generator[AbstractStorage, None, None]:
     module_name = config['module']
     module = importlib.import_module(module_name)
-    return module.open(**config)
+    with module.open(**config) as s:
+        yield s

--- a/recap/storage/notifier.py
+++ b/recap/storage/notifier.py
@@ -1,6 +1,6 @@
 from .abstract import AbstractStorage
 from pathlib import PurePosixPath
-from recap.search.abstract import AbstractIndexer
+from recap.search.abstract import AbstractSearchIndex
 from typing import Any, List
 
 
@@ -8,17 +8,17 @@ class StorageNotifier(AbstractStorage):
     def __init__(
         self,
         storage: AbstractStorage,
-        indexer: AbstractIndexer,
+        index: AbstractSearchIndex,
     ):
         self.storage = storage
-        self.indexer = indexer
+        self.index = index
 
     def touch(
         self,
         path: PurePosixPath,
     ):
         self.storage.touch(path)
-        self.indexer.touched(path)
+        self.index.touched(path)
 
     def write(
         self,
@@ -31,7 +31,7 @@ class StorageNotifier(AbstractStorage):
             type,
             metadata,
         )
-        self.indexer.written(path, type, metadata)
+        self.index.written(path, type, metadata)
 
     def rm(
         self,
@@ -39,7 +39,7 @@ class StorageNotifier(AbstractStorage):
         type: str | None = None,
     ):
         self.storage.rm(path, type)
-        self.indexer.removed(path, type)
+        self.index.removed(path, type)
 
     def ls(
         self,


### PR DESCRIPTION
I'm going to combine the search and index functionality for now. The code is a bit cleaner this way, and I don't have any immediate implementations demanding that they be separated. I might still break them out eventually, but for now, simple is easy.

I also took the opportunity to type hint the `open` methods in the various `__init__` libraries. I had to wrap them in `@contextmanger` and `yield` rather than `return` objects to make pyright happy. But it works.