### PR TITLE
Use sane defaults so `recap` works out of the box

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -277,7 +277,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:b2a893ceda699ed8783b6ea06abad3e19092393743f8a457869871823dbe81ac"
+content_hash = "sha256:0639e4b1d6572b1a6f0fdb1f695f568cd517e593b5915f64086ea99ea81d9a0e"
 
 [metadata.files]
 "anyio 3.6.2" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "dynaconf>=3.1.11",
     "rich>=12.6.0",
     "setuptools>=65.6.3",
+    "duckdb>=0.6.1",
 ]
 requires-python = ">=3.9"
 readme = "README.md"
@@ -25,9 +26,6 @@ license = {text = "MIT"}
 recap = "recap.cli:app"
 
 [project.optional-dependencies]
-duckdb = [
-    "duckdb>=0.6.1",
-]
 jq = [
     "pyjq>=2.6.0",
 ]

--- a/recap/api.py
+++ b/recap/api.py
@@ -8,17 +8,18 @@ from pathlib import PurePosixPath
 from typing import Any, List, Generator
 
 
+DEFAULT_URL = 'http://localhost:8000'
 app = FastAPI()
 
 
 def get_search() -> Generator[AbstractSearchIndex, None, None]:
-    with search.open(**settings['search']) as s:
+    with search.open(**settings('search', {})) as s:
         yield s
 
 
 def get_storage() -> Generator[AbstractStorage, None, None]:
-    with storage.open(**settings['storage']) as st:
-        with search.open(**settings['search']) as se:
+    with storage.open(**settings('storage', {})) as st:
+        with search.open(**settings('search', {})) as se:
             yield StorageNotifier(st, se)
 
 

--- a/recap/config.py
+++ b/recap/config.py
@@ -3,13 +3,13 @@ from dynaconf import Dynaconf
 from pathlib import Path
 
 
-root_path = os.path.join(Path.home(), '.recap')
-Path(root_path).mkdir(parents=True, exist_ok=True)
+RECAP_HOME = os.path.join(Path.home(), '.recap')
+Path(RECAP_HOME).mkdir(parents=True, exist_ok=True)
 
 
 settings = Dynaconf(
     envvar_prefix="RECAP",
     load_dotenv=True,
-    root_path=root_path,
+    root_path=RECAP_HOME,
     settings_files=['settings.toml', '.secrets.toml'],
 )

--- a/recap/crawlers/__init__.py
+++ b/recap/crawlers/__init__.py
@@ -4,14 +4,38 @@ from contextlib import contextmanager
 from recap.crawlers.db import Crawler
 from recap.storage.abstract import AbstractStorage
 from typing import Generator
+from urllib.parse import urlparse
+
+
+def guess_infra(url: str) -> str | None:
+    parsed_url = urlparse(url)
+    # Given `posgrestql+psycopg2://foo:bar@baz/some_db`, return `postgresql`.
+    return parsed_url.scheme.split('+')[0]
+
+def guess_instance(url: str) -> str | None:
+    parsed_url = urlparse(url)
+    # Given `posgrestql+psycopg2://foo:bar@baz/some_db`, return `some_db`.
+    path_fragments = parsed_url \
+        .path \
+        .strip('/') \
+        .split('/')
+    return path_fragments[0] if path_fragments else None
+
 
 @contextmanager
 def open(
-    infra: str,
-    instance: str,
-    storage: AbstractStorage, **config
+    storage: AbstractStorage,
+    **config,
 ) -> Generator[Crawler, None, None]:
-    module_name = config['module']
+    assert 'url' in config, \
+        f"No url defined for crawler config: {config}"
+    default_infra = guess_infra(config['url'])
+    default_instance = guess_instance(config['url'])
+    infra = config.get('infra', default_infra)
+    instance = config.get('instance', default_instance)
+    # This is the only module right now. Should add a guess_module method
+    # (like in storage's `__init__.open`) when we add more.
+    module_name = 'recap.crawlers.db'
     module = importlib.import_module(module_name)
     with module.open(
         infra,

--- a/recap/search/__init__.py
+++ b/recap/search/__init__.py
@@ -1,12 +1,37 @@
 import importlib
 from .abstract import AbstractSearchIndex
+from .duckdb import DEFAULT_URL
 from contextlib import contextmanager
 from typing import Generator
+from urllib.parse import urlparse
+
+
+SCHEMES_TO_MODULES = {
+    'file': 'recap.search.duckdb',
+    'http': 'recap.search.recap',
+}
+
+
+"""
+Tries to get the module to load based on the URL's scheme.
+"""
+def guess_module_name(url: str) -> str | None:
+    parsed_url = urlparse(url)
+    return SCHEMES_TO_MODULES.get(parsed_url.scheme)
 
 
 @contextmanager
 def open(**config) -> Generator[AbstractSearchIndex, None, None]:
-    module_name = config['module']
+    # Default to DuckDB for search if `search.module` isn't configured.
+    url = config.get('url', DEFAULT_URL)
+    guessed_module_name = guess_module_name(url)
+    module_name = config.get('module', guessed_module_name)
+
+    if not module_name:
+        raise ValueError(
+            "No `search.module` config found while creating a "
+            "search index object."
+        )
     module = importlib.import_module(module_name)
     with module.open(**config) as s:
         yield s

--- a/recap/search/jq.py
+++ b/recap/search/jq.py
@@ -3,7 +3,7 @@ import pyjq
 from .abstract import AbstractSearchIndex
 from contextlib import contextmanager
 from pathlib import PurePosixPath
-from recap.storage.fs import FilesystemStorage
+from recap.storage.fs import FilesystemStorage, DEFAULT_URL
 from typing import List, Any, Generator
 from urllib.parse import urlparse
 
@@ -53,7 +53,7 @@ class JqSearchIndex(AbstractSearchIndex):
 
 @contextmanager
 def open(**config) -> Generator[JqSearchIndex, None, None]:
-    url = urlparse(config['url'])
+    url = urlparse(config.get('url', DEFAULT_URL))
     fs_options = config.get('fs', {})
     fs = fsspec.filesystem(
         url.scheme,

--- a/recap/search/recap.py
+++ b/recap/search/recap.py
@@ -2,6 +2,7 @@ import httpx
 from .abstract import AbstractSearchIndex
 from contextlib import contextmanager
 from pathlib import PurePosixPath
+from recap.api import DEFAULT_URL
 from typing import Any, List, Generator
 
 
@@ -36,5 +37,6 @@ class RecapSearchIndex(AbstractSearchIndex):
 
 @contextmanager
 def open(**config) -> Generator[RecapSearchIndex, None, None]:
-    with httpx.Client(base_url=config['url']) as client:
+    url = config.get('url', DEFAULT_URL)
+    with httpx.Client(base_url=url) as client:
         yield RecapSearchIndex(client)

--- a/recap/storage/__init__.py
+++ b/recap/storage/__init__.py
@@ -1,12 +1,57 @@
 import importlib
 from .abstract import AbstractStorage
 from contextlib import contextmanager
+from fsspec.registry import known_implementations
 from typing import Generator
+from urllib.parse import urlparse
+
+
+"""
+Get all fsspec schemes and put them into a dict like:
+{
+    'file': 'recap.storage.fs',
+    's3': 'recap.storage.fs',
+    ...
+}
+"""
+FSSPEC_SCHEMES_TO_MODULES = dict(
+    map(
+        lambda s: (s, 'recap.storage.fs'),
+        known_implementations,
+    )
+)
+
+"""
+`SCHEMES_TO_MODULES` defines the module location for each scheme type.
+"""
+SCHEMES_TO_MODULES = FSSPEC_SCHEMES_TO_MODULES | {
+    # Override fsspec's HTTP reader with Recap's. Users can still use fsspec's
+    # by explicitly setting `module = "recap.storage.fs"`
+    'http': 'recap.storage.recap',
+    # In the future, other implementations like SqliteStorage or DuckDbStorage
+    # could go here, too.
+}
+
+
+"""
+Tries to get the module to load based on the URL's scheme.
+"""
+def guess_module_name(url: str) -> str | None:
+    parsed_url = urlparse(url)
+    return SCHEMES_TO_MODULES.get(parsed_url.scheme)
 
 
 @contextmanager
 def open(**config) -> Generator[AbstractStorage, None, None]:
-    module_name = config['module']
+    # Default to FilesystemStorage if `storage.url` is not set.
+    url = config.get('url', 'file://')
+    guessed_module_name = guess_module_name(url)
+    module_name = config.get('module', guessed_module_name)
+    if not module_name:
+        raise ValueError(
+            f"Unable to find appropriate module for url='{url}'. "
+            "Try setting a 'module' field in the config block."
+        )
     module = importlib.import_module(module_name)
     with module.open(**config) as s:
         yield s

--- a/recap/storage/fs.py
+++ b/recap/storage/fs.py
@@ -3,8 +3,12 @@ import json
 from .abstract import AbstractStorage
 from contextlib import contextmanager
 from pathlib import PurePosixPath
+from recap.config import RECAP_HOME, settings
 from typing import Any, List, Generator
 from urllib.parse import urlparse
+
+
+DEFAULT_URL = f"file://{settings('root_path', RECAP_HOME)}/catalog"
 
 
 class FilesystemStorage(AbstractStorage):
@@ -92,7 +96,7 @@ class FilesystemStorage(AbstractStorage):
 
 @contextmanager
 def open(**config) -> Generator[FilesystemStorage, None, None]:
-    url = urlparse(config['url'])
+    url = urlparse(config.get('url', DEFAULT_URL))
     storage_options = config.get('fs', {})
     fs = fsspec.filesystem(
         url.scheme,

--- a/recap/storage/recap.py
+++ b/recap/storage/recap.py
@@ -2,6 +2,7 @@ import httpx
 from .abstract import AbstractStorage
 from contextlib import contextmanager
 from pathlib import PurePosixPath
+from recap.api import DEFAULT_URL
 from typing import Any, List, Generator
 
 
@@ -50,5 +51,6 @@ class RecapStorage(AbstractStorage):
 
 @contextmanager
 def open(**config) -> Generator[RecapStorage, None, None]:
-    with httpx.Client(base_url=config['url']) as client:
+    url = config.get('url', DEFAULT_URL)
+    with httpx.Client(base_url=url) as client:
         yield RecapStorage(client)


### PR DESCRIPTION
After these changes, the only configs users need to make are to add `[[crawlers]]` entries for the infrastructure they want to crawl.

By default, `duckdb` is used for search and `fs` is used for storage. I had to move `duckdb` back into the main dependencies; I felt this was a better choice than adding `pyjq` since it seemed more prone to build failures.

Users may set a `module` key/value pair in the `storage` and `search` blocks. Here's an example `settings.toml` file that uses Recap storage and search to query a remote Recap API server.

```
[storage]
url = 'http://localhost:8000'

[search]
url = 'http://localhost:8000'

[[crawlers]]
module = "recap.crawlers.db"
url = "postgresql://chrisriccomini@localhost/sticker_space_dev"
```

To use `jq` search, users may add this to their `settings.toml`:

```
[search]
module = "recap.search.jq"
```

There is also an optional `[api]` block, which gets passed straight into `uvicorn`.