### PR TITLE
Rename `crawler` command to `refresh`

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -17,9 +17,8 @@ def api():
     )
 
 
-# TODO convert api and crawler to one `server` command that runs async.
 @app.command()
-def crawler():
+def refresh():
     from . import crawlers
 
     with catalog.open(**settings('catalog', {})) as ca:

--- a/recap/crawlers/db.py
+++ b/recap/crawlers/db.py
@@ -208,7 +208,6 @@ class Crawler:
         self.metadata = metadata
 
     def crawl(self):
-        # TODO should naively loop crawling forever with a sleep between passes
         self.catalog.touch(PurePosixPath(
             'databases', self.infra,
             'instances', self.instance,


### PR DESCRIPTION
I've decided to keep scheduling and orchestration outside of Recap for now. I think it makes sense to write an Airflow/Prefect/Dagster task that calls the appropriate Recap commands. As such, I've shifted the terminology in the CLI to be a little more end-user friendly. Users `refresh` metadata rather than `crawler` it now.