### PR TITLE
Add optional `url` argument to `recap refresh`

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -2,6 +2,7 @@ import typer
 from . import catalog
 from .config import settings
 from rich import print_json
+from typing import Optional
 
 
 app = typer.Typer()
@@ -18,13 +19,24 @@ def api():
 
 
 @app.command()
-def refresh():
+def refresh(url: Optional[str] = typer.Argument(None)):
     from . import crawlers
 
+    # Make sure URL is included in crawlers if it's passed in. This is needed
+    # because Recap works with URLs even if no config was set for it in
+    # settings.toml. It is smart enough to figure out the default module to
+    # use.
+    crawler_config_list = settings('crawlers', [])
+    crawler_urls = set(map(lambda c: c.get('url'), crawler_config_list))
+    if url and url not in crawler_urls:
+        crawler_config_list.append({'url': url})
+
     with catalog.open(**settings('catalog', {})) as ca:
-        for crawler_config in settings('crawlers', {}):
-            with crawlers.open(ca, **crawler_config) as cr:
-                cr.crawl()
+        for crawler_config in crawler_config_list:
+            if not url or url == crawler_config.get('url'):
+                with crawlers.open(ca, **crawler_config) as cr:
+                    cr.crawl()
+
 
 @app.command()
 def search(query: str):


### PR DESCRIPTION
Users may now provide a specific URL to crawl when running `recap refresh`. If set, the URL will be crawled. If there are extrac configs for the same URL in `settings.toml`, those extra configs will be used as well. If no `url` is provided, `recap refresh` will refresh all crawlers defined in `settings.toml`.

Some examples:

```
recap refresh bigquery://some-project-12345
recap refresh postgresql://user@localhost/some_db
```