### PR TITLE
Use host for DB instance name

### DIFF
--- a/recap/crawlers/__init__.py
+++ b/recap/crawlers/__init__.py
@@ -15,7 +15,7 @@ def guess_infra(url: str) -> str | None:
 def guess_instance(url: str) -> str | None:
     parsed_url = urlparse(url)
     # Given `posgrestql+psycopg2://foo:bar@baz/some_db`, return `baz`.
-    return parsed_url.netloc
+    return parsed_url.netloc.split('@')[-1]
 
 
 @contextmanager


### PR DESCRIPTION
The old code used the entire `netloc` field, which includes username and password if they're set. Now, only the host portion is used. For example:

    recap refresh postgresql://chrisriccomini@localhost/some_db

Would use the DB instance `localhost` not `chrisriccomini@localhost`.