### PR TITLE
Use FastAPI app directly in `api` command

### DIFF
--- a/recap/cli.py
+++ b/recap/cli.py
@@ -11,9 +11,10 @@ app = typer.Typer()
 @app.command()
 def api():
     import uvicorn
+    from .api import app
 
     uvicorn.run(
-        "recap.api:app",
+        app,
         **settings('api', {}),
     )
 


### PR DESCRIPTION
Prior to this change, I was using `recap.api:app` when instantiating uvicorn. Now, I'm passing in the actual `app` object from `api.py`.

I was seeing some weird socket leaks when running `recap api` before. I tried to reproduce it after this change and couldn't, so I'm going to declare victory.