### PR TITLE
Add Snowflake support to DB crawler

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -520,7 +520,7 @@ summary = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 
 [metadata]
 lock_version = "4.1"
-content_hash = "sha256:57a5adbde18b9cdd058aa35718d66f4e6f495cc19d0394369a71ce852f3f013a"
+content_hash = "sha256:8e20030159cf5f8bd6b7af94f314e5bbb2f1f18091b5fc3a2bb7191f9b2bb5cf"
 
 [metadata.files]
 "anyio 3.6.2" = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "rich>=12.6.0",
     "setuptools>=65.6.3",
     "duckdb>=0.6.1",
-    "sqlalchemy-bigquery>=1.5.0",
 ]
 # <3.11 to make Recap work with sqlalchemy-bigquery
 requires-python = ">=3.9, <3.11"


### PR DESCRIPTION
DB crawler now works with Snowflake. Users must
`pip install snowflake-sqlalchemy` first. Once installed, users may run a refresh like so:

    recap refresh 'snowflake://SOME_USER:SOME_PASSWORD@SOME_ACCOUNT_ID/SOME_DB?warehouse=SOME_WH'

Recap will crawl the DB's schemas as it does for other databases.

Of course, Snowflake DBs may also be added using `settings.toml`:

```
[[crawlers]]
url = "snowflake://SOME_USER:SOME_PASSWORD@SOME_ACCOUNT_ID/SOME_DB?warehouse=SOME_WH"
```

I had to make a few changes to `db.py` to get Snowflake working.

1. Generic type wasn't working as I expected
2. Added quotes around column names in data profile SQL query
3. Convert `decimal.Decimal` to `float` to make JSON encoding easier

For (1), I thought generic type would return `VARCHAR` when `str()`'ing it. Turns out the output includes the length (`VARCHAR(20)`). I removed lengths for `VARCHAR`s and precision/scale for `NUMERIC`s to make the data profile code easier to work with.

For (2), one of my Snowflake test tables had a column named `INCREMENT` in it. This broke the data profile SQL queries since `INCREMENT` is a reserved word. After some fiddling, I figured out that column names can be escaped with double quotes in Oracle, PostgreSQL, and Snowflake, so I made that change. For Snowflake, I also had to add
`ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = TRUE` because Snowflake uses case-sensitivity by default when double quores surround a column.

For (3), I decided it was safer to convert any `decimal.Decimal` in the data profiler stats results rather than try and guess which fields to cast in the data profiler SQL.

`db.py` is pretty embarassing at this point. I think I'll refactor it after I take a brief detour to update README.md and write some docs.

During these changes, I noticed that `sqlalchemy-bigquery` was still in Recap's package dependencies, so I removed it.