### PR TITLE
Remove `Field` from type hierarchy

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -352,7 +352,23 @@ fields:
     type: com.mycorp.models.LinkedListUint32
 ```
 
-And nested references:
+And attribute overrides:
+
+```yaml
+type: struct
+fields:
+  - name: id
+    alias: com.mycorp.models.Uint24
+    type: int
+    bits: 24
+    signed: false
+  - name: signed_id
+    type: com.mycorp.models.Uint24
+    # Let's make this a signed int24
+    signed: true
+```
+
+But alias inheritance is not allowed:
 
 ```yaml
 type: struct
@@ -365,28 +381,11 @@ fields:
     signed: false
   - name: field2
     type: com.mycorp.models.Field
+    # An alias of an alias isn't allowed.
     alias: com.mycorp.models.FieldAlias
   - name: field3
     type: com.mycorp.models.FieldAlias
 ```
-
-But attribute overrides are ignored:
-
-```yaml
-type: struct
-fields:
-  - name: id
-    alias: com.mycorp.models.Int24
-    type: int
-    bits: 24
-    signed: false
-  - name: signed_id
-    type: com.mycorp.models.Int24
-    # This attribute is ignored.
-    signed: true
-```
-
-Once an attribute is bound, it's considered final for all nested aliases.
 
 ## Logical Types
 

--- a/recap/schema/__init__.py
+++ b/recap/schema/__init__.py
@@ -46,7 +46,19 @@ def diff(
     # Convert to Recap types since diff'ing requires it.
     type_a = convert(schema_obj_a, from_type=obj_a_type)
     type_b = convert(schema_obj_b, from_type=obj_b_type)
-    # Convert Recap types to Recap type objects.
-    type_obj_a = convert(type_a, to_type="recap")
-    type_obj_b = convert(type_b, to_type="recap")
-    return obj_diff(type_obj_a, type_obj_b)
+    recap_diffs = obj_diff(type_a, type_b)
+    diffs = {}
+    for recap_diff in recap_diffs:
+        # Silly hack to prevent fields.[1]
+        path_str = ".".join(recap_diff.path).replace(".[", "[")
+        # Convert types back to schema_obj_a's type.
+        before = (
+            convert(recap_diff.before, to_type=obj_a_type)
+            if recap_diff.before
+            else None
+        )
+        after = (
+            convert(recap_diff.after, to_type=obj_a_type) if recap_diff.after else None
+        )
+        diffs[path_str] = {"before": before, "after": after}
+    return diffs

--- a/recap/schema/converters/bigquery.py
+++ b/recap/schema/converters/bigquery.py
@@ -71,18 +71,12 @@ class BigQueryConverter(Converter):
                         "Can't convert to Recap type from bigquery "
                         f"type={column.field_type}"
                     )
-            field_args = {}
             if column.is_nullable:
                 field_type = types.Union(types=[types.Null(), field_type])
                 # Default to `null` for `is_nullable=True`
-                field_args["default"] = types.Literal(value=None)
+                field_type.extra_attrs["default"] = None
             if default := column.default_value_expression:
-                field_args["default"] = types.Literal(value=default)
-            fields.append(
-                types.Field(
-                    name=column.name,
-                    type_=field_type,
-                    **field_args,
-                )
-            )
+                field_type.extra_attrs["default"] = default
+            field_type.extra_attrs["name"] = column.name
+            fields.append(field_type)
         return types.Struct(fields=fields)

--- a/recap/schema/converters/frictionless.py
+++ b/recap/schema/converters/frictionless.py
@@ -38,10 +38,6 @@ class FrictionlessConverter(Converter):
                         "Can't convert to Recap type from frictionless "
                         f"type={frictionless_field.type}"
                     )
-            fields.append(
-                types.Field(
-                    name=frictionless_field.name,
-                    type_=field_type,
-                )
-            )
+            field_type.extra_attrs["name"] = frictionless_field.name
+            fields.append(field_type)
         return types.Struct(fields=fields)

--- a/recap/schema/converters/proto.py
+++ b/recap/schema/converters/proto.py
@@ -60,12 +60,12 @@ class ProtobufConverter(Converter):
             return field_type
 
         struct_fields = []
+
         for field in descriptor.fields:
-            struct_field = types.Field(name=field.name, type_=_from_proto_field(field))
+            type_ = _from_proto_field(field)
+            type_.extra_attrs["name"] = field.name
             if field.has_default_value:
-                struct_field.default = types.Literal(value=field.default_value)
-            struct_fields.append(
-                struct_field,
-            )
+                type_.extra_attrs["default"] = field.default_value
+            struct_fields.append(type_)
 
         return types.Struct(fields=struct_fields)

--- a/recap/schema/converters/sqlalchemy.py
+++ b/recap/schema/converters/sqlalchemy.py
@@ -79,20 +79,14 @@ class SQLAlchemyConverter(Converter):
                         "Can't convert to Recap type from SQLAlchemy "
                         f"type={type(column['type'])}"
                     )
-            field_args = {}
             if column.get("nullable"):
                 field_type = types.Union(types=[types.Null(), field_type])
                 # Force `null` default since SQLAlchemy doesn't appear to
                 # differentiate between an unset default and a default set to
                 # `null`.
-                field_args["default"] = types.Literal(value=None)
+                field_type.extra_attrs["default"] = None
             if default := column.get("default"):
-                field_args["default"] = types.Literal(value=default)
-            fields.append(
-                types.Field(
-                    name=column["name"],
-                    type_=field_type,
-                    **field_args,
-                )
-            )
+                field_type.extra_attrs["default"] = default
+            field_type.extra_attrs["name"] = column["name"]
+            fields.append(field_type)
         return types.Struct(fields=fields)

--- a/recap/schema/converters/sqlglot.py
+++ b/recap/schema/converters/sqlglot.py
@@ -66,14 +66,20 @@ class SQLGlotConverter(Converter):
                 case types.List():
                     column_def = f"{_get_column_defs(schema.values)}[]"
                 case types.Struct():
-                    for field in schema.fields or []:
-                        field_def = _get_column_defs(field.type_)
-                        if is_root and field.name == primary_key:
-                            field_def += " PRIMARY KEY"
-                        # TODO Support required fields.
-                        # elif not field.type_.optional:
-                        #    field_def += " NOT NULL"
-                        column_def += f"{field.name} {field_def}, "
+                    for field_type in schema.fields or []:
+                        field_def = _get_column_defs(field_type)
+                        if field_name := field_type.extra_attrs.get("name"):
+                            if is_root and field_name == primary_key:
+                                field_def += " PRIMARY KEY"
+                            # TODO Support required fields.
+                            # elif not field.type_.optional:
+                            #    field_def += " NOT NULL"
+                            # TODO Support defaults.
+                            column_def += f"{field_name} {field_def}, "
+                        else:
+                            raise ValueError(
+                                f"Missing field name for type={field_type}"
+                            )
                     column_def = column_def.rstrip(", ")
                     if not is_root:
                         column_def = f"STRUCT({column_def})"

--- a/recap/schema/diff.py
+++ b/recap/schema/diff.py
@@ -1,120 +1,54 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field, fields
 from typing import Any
 
+from recap.schema import types
 
-@dataclass
+
+@dataclass(kw_only=True)
 class Diff:
     """
     A difference for a Recap type attribute before and after it was changed.
     """
 
-    before: Any = None
-    after: Any = None
+    path: list[str] = field(default_factory=list)
+    before: types.Type | None = None
+    after: types.Type | None = None
 
 
-Diffs = dict[str | int, "Diff | Diffs"]
-"""
-A dictionary of diffs representing a diff between two Recap types.
-
-String keys represent attribute names for a Recap type (e.g. "type", "alias",
-etc). Integer keys represent indexes in a list if two lists of types are being
-compared.
-"""
-
-
-def diff(obj_a: Any, obj_b: Any) -> Diffs | Diff:
-    """
-    Compare schema object A to schema object B and return the differences. For
-    example, given obj_a and obj_b as:
-
-    ```
-    obj_a = {
-        "type": "struct",
-        "fields": [
-            {
-                "name": "field1",
-                "type": "int32",
-            },
-            {
-                "name": "field2",
-                "type": "int64",
-            },
-        ],
-    }
-
-    obj_b = {
-        "type": "struct",
-        "fields": [
-            {
-                "name": "field1",
-                "type": "int64",
-            },
-            {
-                "name": "field2",
-                "type": "int64",
-            },
-            {
-                "name": "field3",
-                "type": "list",
-                "values": "string32",
-            },
-        ],
-    }
-    ```
-
-    The returned diff would be:
-
-    ```
-    {'fields': {0: {'type': Diff(before='int32', after='int64')},
-                2: {'name': Diff(before=None, after='field3'),
-                    'type': Diff(before=None, after='list'),
-                    'values': Diff(before=None, after='string32')}}}
-    ```
-
-    :param obj_a: A Recap type in object form.
-    :param obj_a: A second Recap type in object form to compare to the first.
-    :returns: The fields that were added, removed, or changed to get from obj_a
-        to obj_b.
-    """
-
-    match obj_a, obj_b:
-        case (dict(obj), None) | (None, dict(obj)):
-            is_from = obj == obj_a
-            return {
-                attr_name: diff(obj[attr_name], None)
-                if is_from
-                else diff(None, obj[attr_name])
-                for attr_name, attr in obj.items()
-            }
-        case (list(obj), None) | (None, list(obj)):
-            is_from = obj == obj_a
-            return {
-                i: diff(obj[i], None) if is_from else diff(None, obj[i])
-                for i in range(0, len(obj))
-            }
-        case type(type_a), type(type_b) if type_a != type_b:
-            # If types don't match, just return the two objects.
-            return Diff(before=obj_a, after=obj_b)
-        case list(obj_a_list), list(obj_b_list):
-            diffs = {}
-            max_len = max(len(obj_a_list), len(obj_b_list))
-            for i in range(0, max_len):
-                list_a_attr = obj_a_list[i] if i < len(obj_a_list) else None
-                list_b_attr = obj_b_list[i] if i < len(obj_b_list) else None
-                if attr_diff := diff(list_a_attr, list_b_attr):
-                    diffs[i] = attr_diff
-            return diffs
-        case dict(attr_a_dict), dict(attr_b_dict):
-            diffs = {}
-            for attr_name in attr_a_dict.keys() | attr_b_dict.keys():
-                if attr_diff := diff(
-                    attr_a_dict.get(attr_name),
-                    attr_b_dict.get(attr_name),
-                ):
-                    diffs[attr_name] = attr_diff
-            return diffs
-        case attr_a, attr_b if attr_a != attr_b:
-            return Diff(before=attr_a, after=attr_b)
-    return {}
+def diff(
+    type_a: types.Type | None, type_b: types.Type | None, path: list[str] = []
+) -> list[Diff]:
+    if type(type_a) != type(type_b) or not type_a or not type_b:
+        return [Diff(path=path, before=type_a, after=type_b)]
+    elif type_a != type_b:
+        # Types are the same and both are non-null. Compare type fields.
+        diffs = []
+        for type_a_field in fields(type_a):
+            type_a_val = getattr(type_a, type_a_field.name)
+            type_b_val = getattr(type_b, type_a_field.name)
+            match type_a_field.metadata.get(types.FIELD_METADATA_TYPE):
+                case "type":
+                    diffs.extend(
+                        diff(type_a_val, type_b_val, path + [type_a_field.name])
+                    )
+                case "list[type]":
+                    list_a_len = len(type_a_val)
+                    list_b_len = len(type_b_val)
+                    max_len = max(list_a_len, list_b_len)
+                    for i in range(0, max_len):
+                        list_a_subtype = type_a_val[i] if i < list_a_len else None
+                        list_b_subtype = type_b_val[i] if i < list_b_len else None
+                        diffs.extend(
+                            diff(
+                                list_a_subtype,
+                                list_b_subtype,
+                                path + [type_a_field.name, f"[{i}]"],
+                            )
+                        )
+                case _ if type_a_val != type_b_val:
+                    # Found a non-matching primitive attribute, so treat the entire type as different.
+                    return [Diff(path=path, before=type_a, after=type_b)]
+        return diffs
+    return []

--- a/recap/schema/types.py
+++ b/recap/schema/types.py
@@ -88,19 +88,7 @@ class Map(Type):
 @dataclass(kw_only=True)
 class Struct(Type):
     default_alias: ClassVar[str] = "struct"
-    fields: list[Field] = field(metadata={FIELD_METADATA_TYPE: "list[field]"})
-
-
-@dataclass
-class Field:
-    type_: Type
-    name: str | None = None
-    default: Literal | None = None
-
-
-@dataclass
-class Literal:
-    value: Any
+    fields: list[Type] = field(metadata={FIELD_METADATA_TYPE: "list[type]"})
 
 
 @dataclass(kw_only=True)

--- a/tests/schema/converters/test_avro.py
+++ b/tests/schema/converters/test_avro.py
@@ -24,8 +24,8 @@ class TestAvro:
         expected = types.Struct(
             alias="SomeNamespace.Users",
             fields=[
-                types.Field(name="Id", type_=types.Int32()),
-                types.Field(name="Name", type_=types.String64()),
+                types.Int32(extra_attrs={"name": "Id"}),
+                types.String64(extra_attrs={"name": "Name"}),
             ],
         )
         assert struct == expected
@@ -34,8 +34,8 @@ class TestAvro:
         struct = types.Struct(
             alias="Users",
             fields=[
-                types.Field(name="Id", type_=types.Int32()),
-                types.Field(name="Name", type_=types.String64()),
+                types.Int32(extra_attrs={"name": "Id"}),
+                types.String64(extra_attrs={"name": "Name"}),
             ],
         )
         avsc = AvroConverter().from_recap_type(struct)
@@ -70,15 +70,13 @@ class TestAvro:
         expected = types.Struct(
             alias="recap.test.LongList",
             fields=[
-                types.Field(name="value", type_=types.Int64()),
-                types.Field(
-                    name="next",
-                    type_=types.Union(
-                        types=[
-                            types.Null(),
-                            types.Type(alias="recap.test.LongList"),
-                        ]
-                    ),
+                types.Int64(extra_attrs={"name": "value"}),
+                types.Union(
+                    types=[
+                        types.Null(),
+                        types.Type(alias="recap.test.LongList"),
+                    ],
+                    extra_attrs={"name": "next"},
                 ),
             ],
         )
@@ -88,15 +86,13 @@ class TestAvro:
         struct = types.Struct(
             alias="recap.test.LongList",
             fields=[
-                types.Field(name="value", type_=types.Int64()),
-                types.Field(
-                    name="next",
-                    type_=types.Union(
-                        types=[
-                            types.Null(),
-                            types.Type(alias="recap.test.LongList"),
-                        ]
-                    ),
+                types.Int64(extra_attrs={"name": "value"}),
+                types.Union(
+                    types=[
+                        types.Null(),
+                        types.Type(alias="recap.test.LongList"),
+                    ],
+                    extra_attrs={"name": "next"},
                 ),
             ],
         )

--- a/tests/schema/converters/test_json_schema.py
+++ b/tests/schema/converters/test_json_schema.py
@@ -17,8 +17,8 @@ class TestJsonSchema:
         struct = JsonSchemaConverter().to_recap_type(jsc)
         expected = types.Struct(
             fields=[
-                types.Field(name="number", type_=types.Float64()),
-                types.Field(name="street_name", type_=types.String32()),
+                types.Float64(extra_attrs={"name": "number"}),
+                types.String32(extra_attrs={"name": "street_name"}),
             ],
         )
         assert struct == expected

--- a/tests/schema/converters/test_proto.py
+++ b/tests/schema/converters/test_proto.py
@@ -32,30 +32,28 @@ class TestProtoConverter:
         recap_schema = ProtobufConverter().to_recap_type(search_response_descriptor)
         assert isinstance(recap_schema, types.Struct)
         assert len(recap_schema.fields) == 1
-        field = recap_schema.fields[0]
-        assert field.name == "results"
-        assert isinstance(field, types.Field)
-        schema = field.type_
-        assert isinstance(schema, types.List)
-        result_schema = schema.values
-        assert isinstance(result_schema, types.Struct)
-        assert len(result_schema.fields) == 3
-        assert result_schema.fields[0].name == "url"
-        assert result_schema.fields[0].type_ == types.Union(
+        field_type = recap_schema.fields[0]
+        assert field_type.extra_attrs.get("name") == "results"
+        assert isinstance(field_type, types.List)
+        struct_type = field_type.values
+        assert isinstance(struct_type, types.Struct)
+        assert len(struct_type.fields) == 3
+        assert struct_type.fields[0] == types.Union(
             types=[
                 types.Null(),
                 types.String32(),
-            ]
+            ],
+            extra_attrs={"name": "url"},
         )
-        assert result_schema.fields[1].name == "title"
-        assert result_schema.fields[1].type_ == types.Union(
+        assert struct_type.fields[1] == types.Union(
             types=[
                 types.Null(),
                 types.String32(),
-            ]
+            ],
+            extra_attrs={"name": "title"},
         )
-        assert result_schema.fields[2].name == "snippets"
-        result_snippets_schema = result_schema.fields[2].type_
+        assert struct_type.fields[2].extra_attrs.get("name") == "snippets"
+        result_snippets_schema = struct_type.fields[2]
         assert isinstance(result_snippets_schema, types.List)
         snippet_value_schema = result_snippets_schema.values
         assert isinstance(snippet_value_schema, types.String32)

--- a/tests/schema/test_types.py
+++ b/tests/schema/test_types.py
@@ -15,7 +15,7 @@ class TestTypes:
         parsed = RecapConverter().to_recap_type(obj)
         expected = types.Struct(
             fields=[
-                types.Field(type_=types.Int32()),
+                types.Int32(),
             ],
         )
         assert parsed == expected
@@ -33,11 +33,9 @@ class TestTypes:
         parsed = RecapConverter().to_recap_type(obj)
         expected = types.Struct(
             fields=[
-                types.Field(
-                    type_=types.List(
-                        values=types.Int32(),
-                    )
-                ),
+                types.List(
+                    values=types.Int32(),
+                )
             ],
         )
         assert parsed == expected
@@ -62,22 +60,20 @@ class TestTypes:
         expected = types.Struct(
             alias="com.mycorp.models.LinkedListUint32",
             fields=[
-                types.Field(
-                    name="value",
-                    type_=types.Int32(),
-                ),
-                types.Field(
-                    name="next",
-                    type_=ProxyType(
-                        obj=obj,
-                        converter=converter,
-                    ),
+                types.Int32(extra_attrs={"name": "value"}),
+                ProxyType(
+                    obj=obj,
+                    converter=converter,
+                    extra_attrs={
+                        "name": "next",
+                        "type": "com.mycorp.models.LinkedListUint32",
+                    },
                 ),
             ],
         )
         assert parsed == expected
 
-    def test_alias_of_alias_sdl_to_recap(self):
+    def test_multiple_aliases_sdl_to_recap(self):
         obj = {
             "type": "struct",
             "fields": [
@@ -89,30 +85,31 @@ class TestTypes:
                 {
                     "name": "field2",
                     "type": "com.mycorp.models.Int32",
-                    "alias": "com.mycorp.models.OtherInt32",
-                    # Additional attributes are ignored.
+                    # Overwriting alias attributes is allowed
                     "bits": 24,
+                    # Extra attriutes go into extra_attrs
+                    "an_extra": True,
                 },
                 {
                     "name": "field3",
-                    "type": "com.mycorp.models.OtherInt32",
+                    "type": "com.mycorp.models.Int32",
                 },
             ],
         }
         parsed = RecapConverter().to_recap_type(obj)
         expected = types.Struct(
             fields=[
-                types.Field(
-                    name="field1",
-                    type_=types.Int32(alias="com.mycorp.models.Int32"),
+                types.Int32(
+                    alias="com.mycorp.models.Int32", extra_attrs={"name": "field1"}
                 ),
-                types.Field(
-                    name="field2",
-                    type_=types.Int32(alias="com.mycorp.models.OtherInt32"),
+                types.Int32(
+                    alias="com.mycorp.models.Int32",
+                    bits=24,
+                    extra_attrs={"an_extra": True, "name": "field2"},
                 ),
-                types.Field(
-                    name="field3",
-                    type_=types.Int32(alias="com.mycorp.models.OtherInt32"),
+                types.Int32(
+                    alias="com.mycorp.models.Int32",
+                    extra_attrs={"name": "field3"},
                 ),
             ],
         )
@@ -127,9 +124,6 @@ class TestTypes:
                 {
                     "name": "next",
                     "type": "com.mycorp.models.LinkedListUint32",
-                    "alias": "com.mycorp.models.Nested",
-                    # Additional attributes are ignored.
-                    "bits": 24,
                 },
                 {
                     "name": "extra_field",
@@ -137,8 +131,7 @@ class TestTypes:
                     "fields": [
                         {
                             "name": "extra_struct",
-                            "type": "com.mycorp.models.Nested",
-                            "alias": "com.mycorp.models.Unused",
+                            "type": "com.mycorp.models.LinkedListUint32",
                         }
                     ],
                 },
@@ -149,38 +142,33 @@ class TestTypes:
         expected = types.Struct(
             alias="com.mycorp.models.LinkedListUint32",
             fields=[
-                types.Field(
-                    name="value",
-                    type_=types.Union(
-                        types=[
-                            types.Null(),
-                            types.Int32(),
-                        ]
-                    ),
-                    default=types.Literal(None),
+                types.Union(
+                    types=[
+                        types.Null(),
+                        types.Int32(),
+                    ],
+                    extra_attrs={"name": "value", "default": None},
                 ),
-                types.Field(
-                    name="next",
-                    type_=ProxyType(
-                        alias="com.mycorp.models.Nested",
-                        obj=obj,
-                        converter=converter,
-                    ),
+                ProxyType(
+                    obj=obj,
+                    converter=converter,
+                    extra_attrs={
+                        "type": "com.mycorp.models.LinkedListUint32",
+                        "name": "next",
+                    },
                 ),
-                types.Field(
-                    name="extra_field",
-                    type_=types.Struct(
-                        fields=[
-                            types.Field(
-                                name="extra_struct",
-                                type_=ProxyType(
-                                    alias="com.mycorp.models.Unused",
-                                    obj=obj,
-                                    converter=converter,
-                                ),
-                            )
-                        ],
-                    ),
+                types.Struct(
+                    fields=[
+                        ProxyType(
+                            obj=obj,
+                            converter=converter,
+                            extra_attrs={
+                                "type": "com.mycorp.models.LinkedListUint32",
+                                "name": "extra_struct",
+                            },
+                        ),
+                    ],
+                    extra_attrs={"name": "extra_field"},
                 ),
             ],
         )


### PR DESCRIPTION
I've removed the `types.Field` class to simplify a lot of the code. Having a special non-Type class inside `Struct` was complicating things.

I also decided to change the spec to prevent nested alias (alias inheritance). I found that once I did this, a lot of things became easier to implement.

I re-added support for attribute overrides in alias types, so:

```
{
    "type": "some.other.Alias",
    "an_attr": true
}
```

Will override `an_attr` in the base `some.other.Alias` for the derived type.

Lastly, all of this was spurred on by my initial attempt at converting `diff`'s back to non-Recap types. I thought it would be cool to `diff` two Avros and get back an Avro as a response. The tweaks above all made this possible. I've updated `diff` to return the diff in the input schema's dialect rather than as a Recap type.