### PR TITLE
Add basic ProtobufConverter

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -2,6 +2,11 @@
 # It is not intended for manual editing.
 
 [[package]]
+name = "antlr4-python3-runtime"
+version = "4.13.0"
+summary = "ANTLR 4.13.0 runtime for Python 3"
+
+[[package]]
 name = "asn1crypto"
 version = "1.5.1"
 summary = "Fast ASN.1 parser and serializer with definitions for private keys, public keys, certificates, CRL, OCSP, CMS, PKCS#3, PKCS#7, PKCS#8, PKCS#12, PKCS#5, X.509 and TSP"
@@ -210,6 +215,15 @@ requires_python = ">=3.6"
 summary = "plugin and hook calling mechanisms for python"
 
 [[package]]
+name = "proto-schema-parser"
+version = "0.2.0"
+requires_python = ">=3.8"
+summary = "A Pure Python Protobuf 3 .proto Parser"
+dependencies = [
+    "antlr4-python3-runtime>=4.13.0",
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.6"
 requires_python = ">=3.6"
@@ -382,10 +396,14 @@ summary = "Module for decorators, wrappers and monkey patching."
 [metadata]
 lock_version = "4.2"
 cross_platform = true
-groups = ["default", "kafka", "style", "tests"]
-content_hash = "sha256:6ccd09a4525e2f3413f8d30a27ea8787f4b5b839aba67107e2c8fb5118239a3b"
+groups = ["default", "kafka", "proto", "style", "tests"]
+content_hash = "sha256:75157ba85be0c5d449d2541faa67a9039de7a2871ccacdb368d5f369c0177a08"
 
 [metadata.files]
+"antlr4-python3-runtime 4.13.0" = [
+    {url = "https://files.pythonhosted.org/packages/44/ff/72821c7790e33cd54bfd4b4a948da4cc240a6533aa26061d246a290c9166/antlr4_python3_runtime-4.13.0-py3-none-any.whl", hash = "sha256:53e6e208cf4a1ad53fb8b1b4467b756375a4f827331e290618aedcf481cb1d5c"},
+    {url = "https://files.pythonhosted.org/packages/e3/fe/db1120682e306744a3cc3ae06fc26692d95da5b8432382d8e86140f0afc6/antlr4-python3-runtime-4.13.0.tar.gz", hash = "sha256:0d5454928ae40c8a6b653caa35046cd8492c8743b5fbc22ff4009099d074c7ae"},
+]
 "asn1crypto 1.5.1" = [
     {url = "https://files.pythonhosted.org/packages/c9/7f/09065fd9e27da0eda08b4d6897f1c13535066174cc023af248fc2a8d5e5a/asn1crypto-1.5.1-py2.py3-none-any.whl", hash = "sha256:db4e40728b728508912cbb3d44f19ce188f218e9eba635821bb4b68564f8fd67"},
     {url = "https://files.pythonhosted.org/packages/de/cf/d547feed25b5244fcb9392e288ff9fdc3280b10260362fc45d37a798a6ee/asn1crypto-1.5.1.tar.gz", hash = "sha256:13ae38502be632115abf8a24cbe5f4da52e3b5231990aff31123c805306ccb9c"},
@@ -806,6 +824,10 @@ content_hash = "sha256:6ccd09a4525e2f3413f8d30a27ea8787f4b5b839aba67107e2c8fb511
 "pluggy 1.0.0" = [
     {url = "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {url = "https://files.pythonhosted.org/packages/a1/16/db2d7de3474b6e37cbb9c008965ee63835bba517e22cdb8c35b5116b5ce1/pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+"proto-schema-parser 0.2.0" = [
+    {url = "https://files.pythonhosted.org/packages/37/d7/89dd93f92a71b987b39ca7fd940b351264abc99426a079e79fea1e24d261/proto_schema_parser-0.2.0-py3-none-any.whl", hash = "sha256:d30521d3b6c0225dcf7b89536b7ebfdbefdef8b638b88346f29b7dead66dea58"},
+    {url = "https://files.pythonhosted.org/packages/ae/2d/5a824f2c515f3349578680748490024cfcdaecd76acf9bdb220a41afbd46/proto_schema_parser-0.2.0.tar.gz", hash = "sha256:463549990b3ecbaa6cc0584ab27bfc63e084f55b1639cef9cd877cf5a9f3911b"},
 ]
 "psycopg2-binary 2.9.6" = [
     {url = "https://files.pythonhosted.org/packages/01/76/512f0a878dd900902ed818156baccaf94c05d0450534f7b4f714932e3d7e/psycopg2_binary-2.9.6-cp311-cp311-win32.whl", hash = "sha256:1876843d8e31c89c399e31b97d4b9725a3575bb9c2af92038464231ec40f9edb"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ repository = "https://github.com/recap-cloud/recap"
 kafka = [
     "confluent-kafka[schema-registry]>=2.1.1",
 ]
+proto = [
+    "proto-schema-parser>=0.2.0",
+]
 
 [build-system]
 requires = ["pdm-pep517>=1.0.0"]
@@ -42,7 +45,6 @@ tests = [
     # For snowflake
     "snowflake-connector-python>=3.0.4",
     "fakesnow>=0.1.0",
-    # For fakesnow
     # For postgres
     "psycopg2-binary>=2.9.6",
 ]

--- a/recap/converters/avro.py
+++ b/recap/converters/avro.py
@@ -85,7 +85,10 @@ class AvroConverter:
         return return_type
 
     def _parse_logical(
-        self, logical_type: str, avro_schema: dict, extra_attrs: dict
+        self,
+        logical_type: str,
+        avro_schema: dict,
+        extra_attrs: dict,
     ) -> RecapType:
         match logical_type:
             case "decimal":

--- a/recap/converters/protobuf.py
+++ b/recap/converters/protobuf.py
@@ -1,0 +1,176 @@
+from proto_schema_parser.ast import (
+    Enum,
+    EnumValue,
+    Field,
+    FieldCardinality,
+    MapField,
+    Message,
+    OneOf,
+)
+from proto_schema_parser.parser import Parser
+
+from recap.types import (
+    BoolType,
+    BytesType,
+    EnumType,
+    FloatType,
+    IntType,
+    ListType,
+    MapType,
+    NullType,
+    ProxyType,
+    RecapType,
+    StringType,
+    StructType,
+    UnionType,
+)
+
+
+class ProtobufConverter:
+    def convert(self, protobuf_schema_str: str) -> StructType:
+        file = Parser().parse(protobuf_schema_str)
+        root_message = self._parse(file)
+        root_message = self._resolve_proxies(root_message)
+
+        if not isinstance(root_message, StructType):
+            raise ValueError("Protobuf schema must be a Message")
+
+        return root_message
+
+    def _resolve_proxies(self, recap_type: RecapType | str) -> RecapType:
+        if isinstance(recap_type, str):
+            recap_type = RecapType.from_alias(recap_type)
+
+        if isinstance(recap_type, ProxyType):
+            return recap_type.resolve()
+
+        if isinstance(recap_type, ListType):
+            return ListType(values=self._resolve_proxies(recap_type.values))
+
+        if isinstance(recap_type, MapType):
+            return MapType(
+                keys=self._resolve_proxies(recap_type.keys),
+                values=self._resolve_proxies(recap_type.values),
+            )
+
+        if isinstance(recap_type, UnionType):
+            return UnionType(types=[self._resolve_proxies(t) for t in recap_type.types])
+
+        if isinstance(recap_type, StructType):
+            return StructType(
+                fields=[self._resolve_proxies(f) for f in recap_type.fields],
+            )
+
+        return recap_type
+
+    def _parse(self, file) -> StructType:
+        root_message = None
+
+        for file_element in file.file_elements:
+            if isinstance(file_element, Message):
+                struct_type = self._parse_message(file_element)
+                root_message = root_message or struct_type
+            elif isinstance(file_element, Enum):
+                self._parse_enum(file_element)
+
+        if root_message is None:
+            raise ValueError("Protobuf schema must contain at least one Message")
+
+        return root_message
+
+    def _parse_message(self, message: Message) -> StructType:
+        fields = []
+
+        for element in message.elements:
+            if isinstance(element, Field):
+                recap_type = self._parse_field(element)
+                fields.append(recap_type)
+            elif isinstance(element, MapField):
+                recap_type = self._parse_map_field(element)
+                fields.append(recap_type)
+            elif isinstance(element, OneOf):
+                recap_type = self._parse_oneof(element)
+                fields.append(recap_type)
+            elif isinstance(element, Message):
+                self._parse_message(element)
+            elif isinstance(element, Enum):
+                self._parse_enum(element)
+
+        return StructType(fields=fields, alias=message.name)
+
+    def _parse_field(self, field: Field) -> RecapType:
+        try:
+            recap_type = self._protobuf_type_to_recap_type(field.type)
+        except ValueError:
+            # Create a ProxyType and hope we have a type alias for this type.
+            recap_type = ProxyType(alias=field.type)
+
+        if field.cardinality == FieldCardinality.REPEATED:
+            recap_type = ListType(values=recap_type)
+
+        if field.cardinality != FieldCardinality.REQUIRED:
+            recap_type = UnionType(types=[NullType(), recap_type])
+
+        return recap_type
+
+    def _parse_map_field(self, field: MapField) -> RecapType:
+        key_type = self._protobuf_type_to_recap_type(field.key_type)
+        value_type = self._protobuf_type_to_recap_type(field.value_type)
+        return MapType(keys=key_type, values=value_type)
+
+    def _protobuf_type_to_recap_type(self, protobuf_type: str) -> RecapType:
+        match protobuf_type:
+            case "string":
+                return StringType(bytes_=2_147_483_648, variable=True)
+            case "bool":
+                return BoolType()
+            case "bytes":
+                return BytesType(bytes_=2_147_483_648, variable=True)
+            case "int32":
+                return IntType(bits=32)
+            case "int64":
+                return IntType(bits=64)
+            case "uint32":
+                return IntType(bits=32, signed=False)
+            case "uint64":
+                return IntType(bits=64, signed=False)
+            case "sint32":
+                return IntType(bits=32)
+            case "sint64":
+                return IntType(bits=64)
+            case "float":
+                return FloatType(bits=32)
+            case "double":
+                return FloatType(bits=64)
+            case "fixed32":
+                return IntType(bits=32, signed=False)
+            case "fixed64":
+                return IntType(bits=64, signed=False)
+            case "sfixed32":
+                return IntType(bits=32)
+            case "sfixed64":
+                return IntType(bits=64)
+            case _:
+                raise ValueError(f"Type '{protobuf_type}' not supported")
+
+    def _parse_oneof(self, oneof: OneOf) -> RecapType:
+        types: list[RecapType | str] = [NullType()]
+        for element in oneof.elements:
+            if isinstance(element, Field):
+                # !! HACK !!
+                # Force oneof subfield to be required since we're unioning with null above.
+                # Otherwise we end up with [NullType, [NullType, RecapType], ...].
+                # This is safe to force because oneof subfields can't be repeated.
+                original_cardinality = element.cardinality
+                element.cardinality = FieldCardinality.REQUIRED
+                recap_type = self._parse_field(element)
+                element.cardinality = original_cardinality
+                types.append(recap_type)
+        return UnionType(types=types)
+
+    def _parse_enum(self, enum: Enum) -> RecapType:
+        symbols = []
+        for element in enum.elements:
+            if isinstance(element, EnumValue):
+                symbols.append(element.name)
+        return EnumType(symbols=symbols, alias=enum.name)

--- a/tests/converters/test_protobuf.py
+++ b/tests/converters/test_protobuf.py
@@ -1,0 +1,290 @@
+from recap.converters.protobuf import ProtobufConverter
+from recap.types import (
+    BoolType,
+    BytesType,
+    EnumType,
+    FloatType,
+    IntType,
+    ListType,
+    MapType,
+    NullType,
+    StringType,
+    StructType,
+    UnionType,
+)
+
+
+def test_protobuf_converter():
+    protobuf_schema = """
+    syntax = "proto3";
+    message Test2 {
+        string name = 1;
+        bool is_valid = 2;
+        bytes data = 3;
+        int32 id = 4;
+        int64 large_id = 5;
+        uint32 uid = 6;
+        uint64 large_uid = 7;
+        sint32 sid = 8;
+        sint64 large_sid = 9;
+        float score = 10;
+        double large_score = 11;
+        fixed32 fixed_id = 12;
+        fixed64 large_fixed_id = 13;
+        sfixed32 sfixed_id = 14;
+        sfixed64 large_sfixed_id = 15;
+    }
+    """
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 15
+
+    # Field 1: string name = 1;
+    assert isinstance(fields[0], UnionType)
+    assert isinstance(fields[0].types[1], StringType)
+    assert fields[0].types[1].bytes_ == 2_147_483_648
+    assert fields[0].types[1].variable == True
+
+    # Field 2: bool is_valid = 2;
+    assert isinstance(fields[1], UnionType)
+    assert isinstance(fields[1].types[1], BoolType)
+
+    # Field 3: bytes data = 3;
+    assert isinstance(fields[2], UnionType)
+    assert isinstance(fields[2].types[1], BytesType)
+    assert fields[2].types[1].bytes_ == 2_147_483_648
+    assert fields[2].types[1].variable == True
+
+    # Field 4: int32 id = 4;
+    assert isinstance(fields[3], UnionType)
+    assert isinstance(fields[3].types[1], IntType)
+    assert fields[3].types[1].bits == 32
+    assert fields[3].types[1].signed == True
+
+    # Field 5: int64 large_id = 5;
+    assert isinstance(fields[4], UnionType)
+    assert isinstance(fields[4].types[1], IntType)
+    assert fields[4].types[1].bits == 64
+    assert fields[4].types[1].signed == True
+
+    # Field 6: uint32 uid = 6;
+    assert isinstance(fields[5], UnionType)
+    assert isinstance(fields[5].types[1], IntType)
+    assert fields[5].types[1].bits == 32
+    assert fields[5].types[1].signed == False
+
+    # Field 7: uint64 large_uid = 7;
+    assert isinstance(fields[6], UnionType)
+    assert isinstance(fields[6].types[1], IntType)
+    assert fields[6].types[1].bits == 64
+    assert fields[6].types[1].signed == False
+
+    # Field 8: sint32 sid = 8;
+    assert isinstance(fields[7], UnionType)
+    assert isinstance(fields[7].types[1], IntType)
+    assert fields[7].types[1].bits == 32
+    assert fields[7].types[1].signed == True
+
+    # Field 9: sint64 large_sid = 9;
+    assert isinstance(fields[8], UnionType)
+    assert isinstance(fields[8].types[1], IntType)
+    assert fields[8].types[1].bits == 64
+    assert fields[8].types[1].signed == True
+
+    # Field 10: float score = 10;
+    assert isinstance(fields[9], UnionType)
+    assert isinstance(fields[9].types[1], FloatType)
+    assert fields[9].types[1].bits == 32
+
+    # Field 11: double large_score = 11;
+    assert isinstance(fields[10], UnionType)
+    assert isinstance(fields[10].types[1], FloatType)
+    assert fields[10].types[1].bits == 64
+
+    # Field 12: fixed32 fixed_id = 12;
+    assert isinstance(fields[11], UnionType)
+    assert isinstance(fields[11].types[1], IntType)
+    assert fields[11].types[1].bits == 32
+    assert fields[11].types[1].signed == False
+
+    # Field 13: fixed64 large_fixed_id = 13;
+    assert isinstance(fields[12], UnionType)
+    assert isinstance(fields[12].types[1], IntType)
+    assert fields[12].types[1].bits == 64
+    assert fields[12].types[1].signed == False
+
+    # Field 14: sfixed32 sfixed_id = 14;
+    assert isinstance(fields[13], UnionType)
+    assert isinstance(fields[13].types[1], IntType)
+    assert fields[13].types[1].bits == 32
+    assert fields[13].types[1].signed == True
+
+    # Field 15: sfixed64 large_sfixed_id = 15;
+    assert isinstance(fields[14], UnionType)
+    assert isinstance(fields[14].types[1], IntType)
+    assert fields[14].types[1].bits == 64
+    assert fields[14].types[1].signed == True
+
+
+def test_protobuf_converter_repeated():
+    protobuf_schema = """
+        syntax = "proto3";
+        message Test3 {
+            repeated int32 values = 1;
+        }
+    """
+
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    # Field 1: repeated int32 values = 1;
+    assert isinstance(fields[0], UnionType)
+    assert isinstance(fields[0].types[1], ListType)
+    assert isinstance(fields[0].types[1].values, IntType)
+    assert fields[0].types[1].values.bits == 32
+    assert fields[0].types[1].values.signed == True
+
+
+def test_protobuf_converter_map():
+    protobuf_schema = """
+        syntax = "proto3";
+        message Test4 {
+            map<string, int32> value = 1;
+        }
+    """
+
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    # Field 1: map<string, int32> value = 1;
+    assert isinstance(fields[0], MapType)
+
+    assert isinstance(fields[0].keys, StringType)
+    assert fields[0].keys.bytes_ == 2_147_483_648
+    assert fields[0].keys.variable == True
+
+    assert isinstance(fields[0].values, IntType)
+    assert fields[0].values.bits == 32
+    assert fields[0].values.signed == True
+
+
+def test_protobuf_converter_forward_reference():
+    protobuf_schema = """
+        syntax = "proto3";
+        message Outer1 {
+            Inner1 value = 1;
+        }
+
+        message Inner1 {
+            int32 value = 1;
+        }
+    """
+
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    # Outer
+    assert isinstance(fields[0], UnionType)
+    assert isinstance(fields[0].types[1], StructType)
+    inner_fields = fields[0].types[1].fields
+    assert len(inner_fields) == 1
+
+    # Inner
+    assert isinstance(inner_fields[0], UnionType)
+    assert isinstance(inner_fields[0].types[1], IntType)
+    assert inner_fields[0].types[1].bits == 32
+    assert inner_fields[0].types[1].signed == True
+
+
+def test_protobuf_converter_nested_message():
+    protobuf_schema = """
+        syntax = "proto3";
+        message Outer2 {
+            message Inner2 {
+                int32 value = 1;
+            }
+            Inner2 value = 2;
+        }
+    """
+
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    # Outer
+    assert isinstance(fields[0], UnionType)
+    assert isinstance(fields[0].types[1], StructType)
+    inner_fields = fields[0].types[1].fields
+    assert len(inner_fields) == 1
+
+    # Inner
+    assert isinstance(inner_fields[0], UnionType)
+    assert isinstance(inner_fields[0].types[1], IntType)
+    assert inner_fields[0].types[1].bits == 32
+    assert inner_fields[0].types[1].signed == True
+
+
+def test_protobuf_converter_enum():
+    protobuf_schema = """
+        syntax = "proto3";
+        message WeatherReport {
+            Season season = 1;
+        }
+        enum Season {
+            SPRING = 0;
+            SUMMER = 1;
+            AUTUMN = 2;
+            WINTER = 3;
+        }
+    """
+
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+    assert isinstance(fields[0], UnionType)
+    assert isinstance(fields[0].types[1], EnumType)
+    assert set(fields[0].types[1].symbols) == {"SPRING", "SUMMER", "AUTUMN", "WINTER"}
+
+
+def test_protobuf_converter_oneof():
+    protobuf_schema = """
+        syntax = "proto3";
+        message Contact {
+            oneof contact_type {
+                string email = 1;
+                int64 phone_number = 2;
+            }
+        }
+    """
+
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    # contact_type
+    assert isinstance(fields[0], UnionType)
+    assert len(fields[0].types) == 3
+    oneof_types = fields[0].types
+
+    # Null
+    assert isinstance(oneof_types[0], NullType)
+
+    # Email
+    assert isinstance(oneof_types[1], StringType)
+    assert oneof_types[1].bytes_ == 2_147_483_648
+    assert oneof_types[1].variable == True
+
+    # Phone Number
+    assert isinstance(oneof_types[2], IntType)
+    assert oneof_types[2].bits == 64
+    assert oneof_types[2].signed == True


### PR DESCRIPTION
I've added a basic (and somewhat hacky) ProtobufConverter. The converter uses my [proto-schema-parser](https://github.com/criccomini/proto-schema-parser) library, which is based off of Buf.build's ANTLR4
[lexer and parser](https://github.com/bufbuild/protobuf.com/tree/main/examples/antlr) files.

The converter supports:

* All primitive types
* Message, Enum, `oneof`, and `map` types
* `repeated` fields
* Forward references

The converter does not support cyclic references, namespaces, or imports.

Closes #248