### PR TITLE
Remove global type registry from RecapType

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -7,9 +7,6 @@ from typing import Any
 class RecapType:
     """Base class for all Recap types."""
 
-    # Define and register built-in aliases
-    type_registry: dict[str, RecapType] = {}
-
     def __init__(
         self,
         type_: str,
@@ -23,17 +20,6 @@ class RecapType:
         self.alias = alias
         self.doc = doc
         self.extra_attrs = extra_attrs
-        if alias is not None:
-            if alias in RecapType.type_registry:
-                raise ValueError(f"Alias {alias} is already used.")
-            RecapType.type_registry[alias] = self
-
-    @staticmethod
-    def from_alias(alias: str) -> RecapType:
-        try:
-            return RecapType.type_registry[alias]
-        except KeyError:
-            raise TypeError(f"No RecapType with alias {alias} found.")
 
     def __eq__(self, other):
         if type(self) is type(other):
@@ -196,14 +182,15 @@ class UnionType(RecapType):
 class ProxyType(RecapType):
     """Represents a proxy to an aliased Recap type."""
 
-    def __init__(self, alias: str, **extra_attrs):
+    def __init__(self, alias: str, registry: RecapTypeRegistry, **extra_attrs):
         super().__init__("proxy", **extra_attrs)
         self.alias = alias
+        self.registry = registry
         self._resolved = None
 
     def resolve(self) -> RecapType:
         if self._resolved is None:
-            self._resolved = copy.deepcopy(RecapType.from_alias(self.alias))
+            self._resolved = copy.deepcopy(self.registry.from_alias(self.alias))
             # Apply attribute overrides
             for attr, value in self.extra_attrs.items():
                 if hasattr(self._resolved, attr):
@@ -216,85 +203,100 @@ class ProxyType(RecapType):
         return super().__eq__(other) and self.alias == other.alias
 
 
-# Built-in Aliases
-RecapType.type_registry.update(
-    {
-        "int8": IntType(8, signed=True),
-        "uint8": IntType(8, signed=False),
-        "int16": IntType(16, signed=True),
-        "uint16": IntType(16, signed=False),
-        "int32": IntType(32, signed=True),
-        "uint32": IntType(32, signed=False),
-        "int64": IntType(64, signed=True),
-        "uint64": IntType(64, signed=False),
-        "float16": FloatType(16),
-        "float32": FloatType(32),
-        "float64": FloatType(64),
-        "string32": StringType(bytes_=2_147_483_648, variable=True),
-        "string64": StringType(bytes_=9_223_372_036_854_775_807, variable=True),
-        "bytes32": BytesType(bytes_=2_147_483_648, variable=True),
-        "bytes64": BytesType(bytes_=9_223_372_036_854_775_807, variable=True),
-        "uuid": StringType(logical="build.recap.UUID", bytes_=36, variable=False),
-        "decimal128": BytesType(
-            logical="build.recap.Decimal",
-            bytes_=16,
-            variable=False,
-            precision=28,
-            scale=14,
-        ),
-        "decimal256": BytesType(
-            logical="build.recap.Decimal",
-            bytes_=32,
-            variable=False,
-            precision=56,
-            scale=28,
-        ),
-        "duration64": IntType(
-            logical="build.recap.Duration",
-            bits=64,
-            unit="millisecond",
-        ),
-        "interval128": BytesType(
-            logical="build.recap.Interval",
-            bytes_=16,
-            variable=False,
-            unit="millisecond",
-        ),
-        "time32": IntType(
-            logical="build.recap.Time",
-            bits=32,
-            unit="second",
-        ),
-        "time64": IntType(
-            logical="build.recap.Time",
-            bits=64,
-            unit="second",
-        ),
-        "timestamp64": IntType(
-            logical="build.recap.Timestamp",
-            bits=64,
-            unit="millisecond",
-            timezone="UTC",
-        ),
-        "date32": IntType(
-            logical="build.recap.Date",
-            bits=32,
-            unit="day",
-        ),
-        "date64": IntType(
-            logical="build.recap.Date",
-            bits=64,
-            unit="day",
-        ),
-    }
-)
+class RecapTypeRegistry:
+    """Class that handles Recap type registration and resolution."""
+
+    def __init__(self):
+        # Define and register built-in aliases
+        self._type_registry: dict[str, RecapType] = {
+            "int8": IntType(8, signed=True),
+            "uint8": IntType(8, signed=False),
+            "int16": IntType(16, signed=True),
+            "uint16": IntType(16, signed=False),
+            "int32": IntType(32, signed=True),
+            "uint32": IntType(32, signed=False),
+            "int64": IntType(64, signed=True),
+            "uint64": IntType(64, signed=False),
+            "float16": FloatType(16),
+            "float32": FloatType(32),
+            "float64": FloatType(64),
+            "string32": StringType(bytes_=2_147_483_648, variable=True),
+            "string64": StringType(bytes_=9_223_372_036_854_775_807, variable=True),
+            "bytes32": BytesType(bytes_=2_147_483_648, variable=True),
+            "bytes64": BytesType(bytes_=9_223_372_036_854_775_807, variable=True),
+            "uuid": StringType(logical="build.recap.UUID", bytes_=36, variable=False),
+            "decimal128": BytesType(
+                logical="build.recap.Decimal",
+                bytes_=16,
+                variable=False,
+                precision=28,
+                scale=14,
+            ),
+            "decimal256": BytesType(
+                logical="build.recap.Decimal",
+                bytes_=32,
+                variable=False,
+                precision=56,
+                scale=28,
+            ),
+            "duration64": IntType(
+                logical="build.recap.Duration",
+                bits=64,
+                unit="millisecond",
+            ),
+            "interval128": BytesType(
+                logical="build.recap.Interval",
+                bytes_=16,
+                variable=False,
+                unit="millisecond",
+            ),
+            "time32": IntType(
+                logical="build.recap.Time",
+                bits=32,
+                unit="second",
+            ),
+            "time64": IntType(
+                logical="build.recap.Time",
+                bits=64,
+                unit="second",
+            ),
+            "timestamp64": IntType(
+                logical="build.recap.Timestamp",
+                bits=64,
+                unit="millisecond",
+                timezone="UTC",
+            ),
+            "date32": IntType(
+                logical="build.recap.Date",
+                bits=32,
+                unit="day",
+            ),
+            "date64": IntType(
+                logical="build.recap.Date",
+                bits=64,
+                unit="day",
+            ),
+        }
+
+    def register_alias(self, alias: str, recap_type: RecapType):
+        if alias in self._type_registry:
+            raise ValueError(f"Alias {alias} is already used.")
+        self._type_registry[alias] = recap_type
+
+    def from_alias(self, alias: str) -> RecapType:
+        try:
+            return self._type_registry[alias]
+        except KeyError:
+            raise TypeError(f"No RecapType with alias {alias} found.")
 
 
-def from_dict(type_dict: dict[str, Any]) -> RecapType:
-    type_dict = (
-        type_dict.copy()
-    )  # Create a copy to avoid modifying the input dictionary
-
+def from_dict(
+    type_dict: dict[str, Any],
+    registry: RecapTypeRegistry | None = None,
+) -> RecapType:
+    # Create a copy to avoid modifying the input dictionary
+    type_dict = type_dict.copy()
+    registry = registry or RecapTypeRegistry()
     alias = type_dict.pop("alias", None)
     type_name = type_dict.pop("type", None)
 
@@ -308,9 +310,9 @@ def from_dict(type_dict: dict[str, Any]) -> RecapType:
         union_types = []
         for t in type_name:
             if isinstance(t, dict):
-                union_types.append(from_dict(t))
+                union_types.append(from_dict(t, registry))
             elif isinstance(t, str):
-                union_types.append(from_dict({"type": t}))
+                union_types.append(from_dict({"type": t}, registry))
         recap_type = UnionType(union_types, **type_dict)
     elif isinstance(type_name, str):
         match type_name:
@@ -339,20 +341,23 @@ def from_dict(type_dict: dict[str, Any]) -> RecapType:
             case "list":
                 if "values" not in type_dict:
                     raise ValueError("'values' attribute is required for 'list' type.")
-                recap_type = ListType(from_dict(type_dict.pop("values")), **type_dict)
+                recap_type = ListType(
+                    from_dict(type_dict.pop("values"), registry),
+                    **type_dict,
+                )
             case "map":
                 if "keys" not in type_dict or "values" not in type_dict:
                     raise ValueError(
                         "'keys' and 'values' attributes are required for 'map' type."
                     )
                 recap_type = MapType(
-                    from_dict(type_dict.pop("keys")),
-                    from_dict(type_dict.pop("values")),
+                    from_dict(type_dict.pop("keys"), registry),
+                    from_dict(type_dict.pop("values"), registry),
                     **type_dict,
                 )
             case "struct":
                 type_dict["fields"] = [
-                    from_dict(f) for f in type_dict.get("fields", [])
+                    from_dict(f, registry) for f in type_dict.get("fields", [])
                 ]
                 recap_type = StructType(**type_dict)
             case "enum":
@@ -363,16 +368,17 @@ def from_dict(type_dict: dict[str, Any]) -> RecapType:
                 if "types" not in type_dict:
                     raise ValueError("'types' attribute is required for 'union' type.")
                 recap_type = UnionType(
-                    [from_dict(t) for t in type_dict.pop("types")], **type_dict
+                    [from_dict(t, registry) for t in type_dict.pop("types")],
+                    **type_dict,
                 )
             case _:
-                recap_type = ProxyType(type_name, **type_dict)
+                recap_type = ProxyType(type_name, registry, **type_dict)
     else:
         raise ValueError("'type' must be a string or list.")
 
     # If alias exists, register the created RecapType
     if alias:
-        RecapType.type_registry[alias] = recap_type
+        registry.register_alias(alias, recap_type)
 
     return recap_type
 

--- a/tests/converters/test_protobuf.py
+++ b/tests/converters/test_protobuf.py
@@ -17,7 +17,7 @@ from recap.types import (
 def test_protobuf_converter():
     protobuf_schema = """
     syntax = "proto3";
-    message Test2 {
+    message Test {
         string name = 1;
         bool is_valid = 2;
         bytes data = 3;
@@ -130,7 +130,7 @@ def test_protobuf_converter():
 def test_protobuf_converter_repeated():
     protobuf_schema = """
         syntax = "proto3";
-        message Test3 {
+        message Test {
             repeated int32 values = 1;
         }
     """
@@ -151,7 +151,7 @@ def test_protobuf_converter_repeated():
 def test_protobuf_converter_map():
     protobuf_schema = """
         syntax = "proto3";
-        message Test4 {
+        message Test {
             map<string, int32> value = 1;
         }
     """
@@ -176,11 +176,11 @@ def test_protobuf_converter_map():
 def test_protobuf_converter_forward_reference():
     protobuf_schema = """
         syntax = "proto3";
-        message Outer1 {
-            Inner1 value = 1;
+        message Outer {
+            Inner value = 1;
         }
 
-        message Inner1 {
+        message Inner {
             int32 value = 1;
         }
     """
@@ -206,11 +206,11 @@ def test_protobuf_converter_forward_reference():
 def test_protobuf_converter_nested_message():
     protobuf_schema = """
         syntax = "proto3";
-        message Outer2 {
-            message Inner2 {
+        message Outer {
+            message Inner {
                 int32 value = 1;
             }
-            Inner2 value = 2;
+            Inner value = 2;
         }
     """
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -13,6 +13,7 @@ from recap.types import (
     NullType,
     ProxyType,
     RecapType,
+    RecapTypeRegistry,
     StringType,
     StructType,
     UnionType,
@@ -166,10 +167,10 @@ aliases = [
 
 @pytest.mark.parametrize("alias", aliases)
 def test_aliases(alias):
-    recap_type = from_dict({"type": alias})
+    recap_type_registry = RecapTypeRegistry()
+    recap_type = from_dict({"type": alias}, recap_type_registry)
     assert isinstance(recap_type, ProxyType)
-    assert recap_type.resolve() == RecapType.type_registry[alias]
-    assert isinstance(recap_type.resolve(), type(RecapType.type_registry[alias]))
+    assert recap_type.resolve() == recap_type_registry.from_alias(alias)
 
 
 def test_from_dict_raises_for_missing_type():


### PR DESCRIPTION
A global singleton RecapType.type_registry was causing problems. Parsing schemas multiple times would cause type alias collisions if any type aliases matched.

I replaced the glocal registry with a RecapTypeRegistry class. The logic for tracking aliases is moved into the converters, where it makes more sense, I think. This allows different converters to handle aliases based on how proto/json/avro work.

The converters have been updated to use the new registry class.

Closes #253