### PR TITLE
Support deeply nested messages in ProtobufConverter

### DIFF
--- a/recap/converters/avro.py
+++ b/recap/converters/avro.py
@@ -1,5 +1,4 @@
 import json
-import typing
 
 from recap.types import (
     BoolType,

--- a/recap/converters/protobuf.py
+++ b/recap/converters/protobuf.py
@@ -46,7 +46,7 @@ class ProtobufConverter:
             recap_type = self.registry.from_alias(recap_type)
 
         if isinstance(recap_type, ProxyType):
-            return recap_type.resolve()
+            recap_type = recap_type.resolve()
 
         if isinstance(recap_type, ListType):
             return ListType(values=self._resolve_proxies(recap_type.values))


### PR DESCRIPTION
I found a bug where deeply nested protobufs weren't getting resolved from their ProxyTypes. Fixing.