### PR TITLE
Add JSONSchemaConverter support for ConfluentRegistryReader

### DIFF
--- a/recap/readers/confluent_registry.py
+++ b/recap/readers/confluent_registry.py
@@ -1,8 +1,7 @@
 from confluent_kafka.schema_registry import SchemaRegistryClient
 
 from recap.converters.avro import AvroConverter
-
-# from recap.converters.json_schema import JSONSchemaConverter
+from recap.converters.json_schema import JSONSchemaConverter
 from recap.converters.protobuf import ProtobufConverter
 from recap.types import StructType
 
@@ -18,13 +17,14 @@ class ConfluentRegistryReader:
     def struct(self, topic: str) -> StructType:
         subject = f"{topic}-value"
         registered_schema = self.registry.get_latest_version(subject)
+        schema_str = registered_schema.schema.schema_str
         match registered_schema.schema.schema_type:
             case "AVRO":
-                return AvroConverter().convert(registered_schema.schema.schema_str)
-            # case "JSON":
-            #    return JSONSchemaConverter().convert(registered_schema.schema.schema_str)
+                return AvroConverter().convert(schema_str)
+            case "JSON":
+                return JSONSchemaConverter().convert(schema_str)
             case "PROTOBUF":
-                return ProtobufConverter().convert(registered_schema.schema.schema_str)
+                return ProtobufConverter().convert(schema_str)
             case _:
                 raise ValueError(
                     f"Unsupported schema type {registered_schema.schema.schema_type}"

--- a/tests/integration/readers/test_confluent_registry.py
+++ b/tests/integration/readers/test_confluent_registry.py
@@ -40,6 +40,29 @@ class TestConfluentRegistryReader:
             protobuf_schema,
         )
 
+        # Define and register the JSON schema for the "dummy_topic_json"
+        json_schema_str = """
+        {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "User",
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type": "integer"
+                }
+            },
+            "required": ["name", "age"]
+        }
+        """
+        json_schema = schema_registry.Schema(json_schema_str, "JSON")
+        cls.schema_registry_client.register_schema(
+            "dummy_topic_json-value",
+            json_schema,
+        )
+
     def test_struct_avro(self):
         reader = ConfluentRegistryReader(self.schema_registry_client)
         result = reader.struct("dummy_topic")
@@ -61,3 +84,14 @@ class TestConfluentRegistryReader:
         assert isinstance(result.fields[0].types[1], StringType)
         assert isinstance(result.fields[1], UnionType)
         assert isinstance(result.fields[1].types[1], IntType)
+
+    def test_struct_json(self):
+        reader = ConfluentRegistryReader(self.schema_registry_client)
+        result = reader.struct("dummy_topic_json")
+
+        assert isinstance(result, StructType)
+        assert len(result.fields) == 2
+        assert result.fields[0].extra_attrs["name"] == "name"
+        assert isinstance(result.fields[0], StringType)
+        assert result.fields[1].extra_attrs["name"] == "age"
+        assert isinstance(result.fields[1], IntType)

--- a/tests/unit/readers/test_confluent_registry.py
+++ b/tests/unit/readers/test_confluent_registry.py
@@ -78,3 +78,47 @@ def test_struct_protobuf():
     mock_schema_registry_client.get_latest_version.assert_called_with(
         "dummy_topic-value"
     )
+
+
+def test_struct_json_schema():
+    mock_schema_registry_client = MagicMock(spec=schema_registry.SchemaRegistryClient)
+
+    class MockSchema:
+        schema_type = "JSON"
+        schema_str = """
+        {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "title": "User",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "age": {
+              "type": "integer"
+            }
+          },
+          "required": ["name", "age"]
+        }
+        """
+
+    class MockRegisteredSchema:
+        schema = MockSchema()
+
+    mock_schema_registry_client.get_latest_version.return_value = MockRegisteredSchema()
+
+    reader = ConfluentRegistryReader(mock_schema_registry_client)
+    result = reader.struct("dummy_topic")
+
+    # Check that the schema was converted correctly.
+    assert isinstance(result, StructType)
+    assert len(result.fields) == 2
+    assert result.fields[0].extra_attrs["name"] == "name"
+    assert isinstance(result.fields[0], StringType)
+    assert result.fields[1].extra_attrs["name"] == "age"
+    assert isinstance(result.fields[1], IntType)
+
+    # Check that the get_latest_version method was called with the correct subject.
+    mock_schema_registry_client.get_latest_version.assert_called_with(
+        "dummy_topic-value"
+    )


### PR DESCRIPTION
I've added "JSON" schema type support for the ConfluentRegistryReader. This is a basic implementation that doesn't support schema references.

Closes #249