### PR TITLE
Include `extra_attrs["name"]` for StructType fields in ProtobufConverter

### DIFF
--- a/tests/integration/readers/test_confluent_registry.py
+++ b/tests/integration/readers/test_confluent_registry.py
@@ -80,8 +80,10 @@ class TestConfluentRegistryReader:
 
         assert isinstance(result, StructType)
         assert len(result.fields) == 2
+        assert result.fields[0].extra_attrs["name"] == "name"
         assert isinstance(result.fields[0], UnionType)
         assert isinstance(result.fields[0].types[1], StringType)
+        assert result.fields[1].extra_attrs["name"] == "age"
         assert isinstance(result.fields[1], UnionType)
         assert isinstance(result.fields[1].types[1], IntType)
 

--- a/tests/unit/converters/test_protobuf.py
+++ b/tests/unit/converters/test_protobuf.py
@@ -42,86 +42,101 @@ def test_protobuf_converter():
 
     # Field 1: string name = 1;
     assert isinstance(fields[0], UnionType)
+    assert fields[0].extra_attrs["name"] == "name"
     assert isinstance(fields[0].types[1], StringType)
     assert fields[0].types[1].bytes_ == 2_147_483_648
     assert fields[0].types[1].variable == True
 
     # Field 2: bool is_valid = 2;
     assert isinstance(fields[1], UnionType)
+    assert fields[1].extra_attrs["name"] == "is_valid"
     assert isinstance(fields[1].types[1], BoolType)
 
     # Field 3: bytes data = 3;
     assert isinstance(fields[2], UnionType)
+    assert fields[2].extra_attrs["name"] == "data"
     assert isinstance(fields[2].types[1], BytesType)
     assert fields[2].types[1].bytes_ == 2_147_483_648
     assert fields[2].types[1].variable == True
 
     # Field 4: int32 id = 4;
     assert isinstance(fields[3], UnionType)
+    assert fields[3].extra_attrs["name"] == "id"
     assert isinstance(fields[3].types[1], IntType)
     assert fields[3].types[1].bits == 32
     assert fields[3].types[1].signed == True
 
     # Field 5: int64 large_id = 5;
     assert isinstance(fields[4], UnionType)
+    assert fields[4].extra_attrs["name"] == "large_id"
     assert isinstance(fields[4].types[1], IntType)
     assert fields[4].types[1].bits == 64
     assert fields[4].types[1].signed == True
 
     # Field 6: uint32 uid = 6;
     assert isinstance(fields[5], UnionType)
+    assert fields[5].extra_attrs["name"] == "uid"
     assert isinstance(fields[5].types[1], IntType)
     assert fields[5].types[1].bits == 32
     assert fields[5].types[1].signed == False
 
     # Field 7: uint64 large_uid = 7;
     assert isinstance(fields[6], UnionType)
+    assert fields[6].extra_attrs["name"] == "large_uid"
     assert isinstance(fields[6].types[1], IntType)
     assert fields[6].types[1].bits == 64
     assert fields[6].types[1].signed == False
 
     # Field 8: sint32 sid = 8;
     assert isinstance(fields[7], UnionType)
+    assert fields[7].extra_attrs["name"] == "sid"
     assert isinstance(fields[7].types[1], IntType)
     assert fields[7].types[1].bits == 32
     assert fields[7].types[1].signed == True
 
     # Field 9: sint64 large_sid = 9;
     assert isinstance(fields[8], UnionType)
+    assert fields[8].extra_attrs["name"] == "large_sid"
     assert isinstance(fields[8].types[1], IntType)
     assert fields[8].types[1].bits == 64
     assert fields[8].types[1].signed == True
 
     # Field 10: float score = 10;
     assert isinstance(fields[9], UnionType)
+    assert fields[9].extra_attrs["name"] == "score"
     assert isinstance(fields[9].types[1], FloatType)
     assert fields[9].types[1].bits == 32
 
     # Field 11: double large_score = 11;
     assert isinstance(fields[10], UnionType)
+    assert fields[10].extra_attrs["name"] == "large_score"
     assert isinstance(fields[10].types[1], FloatType)
     assert fields[10].types[1].bits == 64
 
     # Field 12: fixed32 fixed_id = 12;
     assert isinstance(fields[11], UnionType)
+    assert fields[11].extra_attrs["name"] == "fixed_id"
     assert isinstance(fields[11].types[1], IntType)
     assert fields[11].types[1].bits == 32
     assert fields[11].types[1].signed == False
 
     # Field 13: fixed64 large_fixed_id = 13;
     assert isinstance(fields[12], UnionType)
+    assert fields[12].extra_attrs["name"] == "large_fixed_id"
     assert isinstance(fields[12].types[1], IntType)
     assert fields[12].types[1].bits == 64
     assert fields[12].types[1].signed == False
 
     # Field 14: sfixed32 sfixed_id = 14;
     assert isinstance(fields[13], UnionType)
+    assert fields[13].extra_attrs["name"] == "sfixed_id"
     assert isinstance(fields[13].types[1], IntType)
     assert fields[13].types[1].bits == 32
     assert fields[13].types[1].signed == True
 
     # Field 15: sfixed64 large_sfixed_id = 15;
     assert isinstance(fields[14], UnionType)
+    assert fields[14].extra_attrs["name"] == "large_sfixed_id"
     assert isinstance(fields[14].types[1], IntType)
     assert fields[14].types[1].bits == 64
     assert fields[14].types[1].signed == True


### PR DESCRIPTION
I found a little bug while working yesterday. Looks like the ProtobufConverter wasn't setting any extra_attrs. I can't set `docs` because the Buf protobuf lexer discards them. And default is not part of the proto3 syntax. I did miss `name`, though for StructType fields. I'm fixing that here.

Closes #275