### PR TITLE
from_dict() bug fix for union list shorthand

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -368,7 +368,11 @@ def from_dict(
                 if "types" not in type_dict:
                     raise ValueError("'types' attribute is required for 'union' type.")
                 recap_type = UnionType(
-                    [from_dict(t, registry) for t in type_dict.pop("types")],
+                    [
+                        # Handle union list shorthand ["type1", "type2", ...]
+                        from_dict(t if type(t) != str else {"type": t}, registry)
+                        for t in type_dict.pop("types")
+                    ],
                     **type_dict,
                 )
             case _:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -120,20 +120,27 @@ def test_enum_type():
 
 
 def test_union_type():
-    test_dict = {
-        "type": "union",
-        "types": [{"type": "int", "bits": 32}, {"type": "string", "bytes": 32}],
-    }
-    recap_type = from_dict(test_dict)
-    assert isinstance(recap_type, UnionType)
-    assert recap_type.type_ == "union"
-    for type_ in recap_type.types:
-        if isinstance(type_, IntType):
-            assert type_.type_ == "int"
-            assert type_.bits == 32
-        elif isinstance(type_, StringType):
-            assert type_.type_ == "string"
-            assert type_.bytes_ == 32
+    test_dicts = [
+        {
+            "type": "union",
+            "types": [{"type": "int", "bits": 32}, {"type": "string", "bytes": 32}],
+        },
+        {
+            "type": "union",
+            "types": ["int32", "string32"],
+        },
+    ]
+    for test_dict in test_dicts:
+        recap_type = from_dict(test_dict)
+        assert isinstance(recap_type, UnionType)
+        assert recap_type.type_ == "union"
+        for type_ in recap_type.types:
+            if isinstance(type_, IntType):
+                assert type_.type_ == "int"
+                assert type_.bits == 32
+            elif isinstance(type_, StringType):
+                assert type_.type_ == "string"
+                assert type_.bytes_ == 32
 
 
 aliases = [


### PR DESCRIPTION
Small bug fix in the `from_dict()` method to handle union types defined as a list of type names

```
    type: union
    types: ["int32", "string32"]
```

Without this change the recursive call to `from_dict()` is passed a string and fails with

```
type_dict = 'int32', registry = <recap.types.RecapTypeRegistry object at 0x116a2d060>

    def from_dict(
        type_dict: dict[str, Any],
        registry: RecapTypeRegistry | None = None,
    ) -> RecapType:
        # Create a copy to avoid modifying the input dictionary
>       type_dict = type_dict.copy()
E       AttributeError: 'str' object has no attribute 'copy'

recap/types.py:298: AttributeError
```
