### PR TITLE
Add VOID support for HiveMetadataReader

### DIFF
--- a/recap/readers/hive_metastore.py
+++ b/recap/readers/hive_metastore.py
@@ -61,6 +61,8 @@ class HiveMetastoreReader:
                 recap_type = FloatType(bits=32)
             case HPrimitiveType(primitive_type=PrimitiveCategory.DOUBLE):
                 recap_type = FloatType(bits=64)
+            case HPrimitiveType(primitive_type=PrimitiveCategory.VOID):
+                recap_type = NullType(**extra_attrs)
             case HPrimitiveType(primitive_type=PrimitiveCategory.STRING):
                 # TODO: Should handle multi-byte encodings
                 # Using 2^63-1 as the max length because Hive has no defined max.
@@ -151,7 +153,9 @@ class HiveMetastoreReader:
             case _:
                 raise ValueError(f"Unsupported type: {htype}")
 
-        if not isinstance(recap_type, UnionType):
+        if not isinstance(recap_type, UnionType) and not isinstance(
+            recap_type, NullType
+        ):
             # Hive columns are always nullable and default is always null.
             recap_type = UnionType(
                 types=[NullType(), recap_type],

--- a/tests/integration/readers/test_hive_metastore.py
+++ b/tests/integration/readers/test_hive_metastore.py
@@ -90,6 +90,7 @@ def setup_data(hive_client):
         ttypes.FieldSchema(name="col13", type="interval_year_month", comment="c13"),
         ttypes.FieldSchema(name="col14", type="interval_day_time", comment="c14"),
         ttypes.FieldSchema(name="col15", type="binary", comment="c15"),
+        ttypes.FieldSchema(name="col16", type="void", comment="c16"),
     ]
 
     storageDesc = ttypes.StorageDescriptor(
@@ -166,7 +167,7 @@ def test_primitive_types(hive_client):
     table = reader.struct("test_db", "test_table2")
     fields = table.fields
 
-    assert len(fields) == 12
+    assert len(fields) == 13
 
     assert fields[0].extra_attrs["name"] == "col4"
     assert isinstance(fields[0], UnionType)
@@ -262,6 +263,10 @@ def test_primitive_types(hive_client):
     assert isinstance(fields[11].types[1], BytesType)
     assert fields[11].types[1].bytes_ == 2_147_483_647
     assert fields[11].extra_attrs["comment"] == "c15"
+
+    assert fields[12].extra_attrs["name"] == "col16"
+    assert isinstance(fields[12], NullType)
+    assert fields[12].extra_attrs["comment"] == "c16"
 
 
 def test_parameterized_types(hive_client):

--- a/tests/unit/readers/test_hive_metastore.py
+++ b/tests/unit/readers/test_hive_metastore.py
@@ -46,6 +46,7 @@ def test_struct():
             HColumn("col10", HDecimalType(10, 2)),
             HColumn("col11", HVarcharType(100)),
             HColumn("col12", HCharType(100)),
+            HColumn("col13", HPrimitiveType(PrimitiveCategory.VOID)),
         ]
 
     mock_client.get_table.return_value = MockTable
@@ -55,7 +56,7 @@ def test_struct():
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
-    assert len(result.fields) == 12
+    assert len(result.fields) == 13
 
     # Validate each column in the order defined in MockTable
     assert isinstance(result.fields[0], UnionType)
@@ -119,6 +120,9 @@ def test_struct():
     assert result.fields[11].types[1].bytes_ == 100
     assert not result.fields[11].types[1].variable
     assert result.fields[11].extra_attrs["name"] == "col12"
+
+    assert isinstance(result.fields[12], NullType)
+    assert result.fields[12].extra_attrs["name"] == "col13"
 
 
 def test_struct_with_struct_type():


### PR DESCRIPTION
HiveMetadataReader now converts VOID columns to NullTypes.

Closes #282