### PR TITLE
Add Timetsamp, Duration, and NullValue WKTs to ProtobufReader

### DIFF
--- a/recap/converters/protobuf.py
+++ b/recap/converters/protobuf.py
@@ -169,6 +169,32 @@ class ProtobufConverter:
                 return IntType(bits=32)
             case "sfixed64":
                 return IntType(bits=64)
+            # Handle some of Google's well-known types.
+            # Technically, we should honor `import google/protobuf/*.proto` and
+            # make sure the protos match what's expected, but assuming they match
+            # is fine for now.
+            case "google.protobuf.Timestamp":
+                # https://protobuf.dev/reference/protobuf/google.protobuf/#timestamp
+                # Note: Some protobuf values might overrun this since they support
+                # from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+                return IntType(
+                    logical="build.recap.Timestamp",
+                    bits=64,
+                    signed=True,
+                    unit="nanosecond",
+                    timezone="UTC",
+                )
+            case "google.protobuf.Duration":
+                # https://protobuf.dev/reference/protobuf/google.protobuf/#duration
+                # Note: Some protobuf values might overrun this since they support
+                # int64 seconds and int32 nanoseconds.
+                return IntType(
+                    bits=64,
+                    logical="build.recap.Duration",
+                    unit="nanosecond",
+                )
+            case "google.protobuf.NullValue":
+                return NullType()
             case _:
                 raise ValueError(f"Type '{protobuf_type}' not supported")
 

--- a/tests/unit/converters/test_protobuf.py
+++ b/tests/unit/converters/test_protobuf.py
@@ -341,3 +341,65 @@ def test_protobuf_converter_doubly_nested_message():
     assert isinstance(inner_fields[0].types[1], IntType)
     assert inner_fields[0].types[1].bits == 32
     assert inner_fields[0].types[1].signed == True
+
+
+def test_protobuf_converter_timestamp():
+    protobuf_schema = """
+    syntax = "proto3";
+    import "google/protobuf/timestamp.proto";
+    message Test {
+        google.protobuf.Timestamp timestamp = 1;
+    }
+    """
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    assert isinstance(fields[0], UnionType)
+    assert fields[0].extra_attrs["name"] == "timestamp"
+    assert isinstance(fields[0].types[1], IntType)
+    assert fields[0].types[1].logical == "build.recap.Timestamp"
+    assert fields[0].types[1].bits == 64
+    assert fields[0].types[1].signed == True
+    assert fields[0].types[1].extra_attrs["unit"] == "nanosecond"
+    assert fields[0].types[1].extra_attrs["timezone"] == "UTC"
+
+
+def test_protobuf_converter_duration():
+    protobuf_schema = """
+    syntax = "proto3";
+    import "google/protobuf/duration.proto";
+    message Test {
+        google.protobuf.Duration duration = 1;
+    }
+    """
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    assert isinstance(fields[0], UnionType)
+    assert fields[0].extra_attrs["name"] == "duration"
+    assert isinstance(fields[0].types[1], IntType)
+    assert fields[0].types[1].bits == 64
+    assert fields[0].types[1].logical == "build.recap.Duration"
+    assert fields[0].types[1].extra_attrs["unit"] == "nanosecond"
+
+
+def test_protobuf_converter_nullvalue():
+    protobuf_schema = """
+    syntax = "proto3";
+    import "google/protobuf/struct.proto";
+    message Test {
+        google.protobuf.NullValue null_value = 1;
+    }
+    """
+    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    assert isinstance(recap_schema, StructType)
+    fields = recap_schema.fields
+    assert len(fields) == 1
+
+    assert isinstance(fields[0], UnionType)
+    assert fields[0].extra_attrs["name"] == "null_value"
+    assert isinstance(fields[0].types[1], NullType)


### PR DESCRIPTION
I've added basic support for some well-known types.

The logical type mapping for timestamp and duration are somewhat lossy. The Protobuf WKTs support larger values than the `build.recap` logical types. I'm choosing to live with this for now, rather than introduce Protobuf logical types into Recap.

Closes #269