### PR TITLE
Default `bytes` to 64KiB for StringType and BytesType

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -81,7 +81,7 @@ class FloatType(RecapType):
 class StringType(RecapType):
     """Represents a string Recap type."""
 
-    def __init__(self, bytes_: int, variable: bool = True, **extra_attrs):
+    def __init__(self, bytes_: int = 65_536, variable: bool = True, **extra_attrs):
         super().__init__("string", **extra_attrs)
         self.bytes_ = bytes_
         self.variable = variable
@@ -96,7 +96,7 @@ class StringType(RecapType):
 class BytesType(RecapType):
     """Represents a bytes Recap type."""
 
-    def __init__(self, bytes_: int, variable: bool = True, **extra_attrs):
+    def __init__(self, bytes_: int = 65_536, variable: bool = True, **extra_attrs):
         super().__init__("bytes", **extra_attrs)
         self.bytes_ = bytes_
         self.variable = variable
@@ -329,14 +329,12 @@ def from_dict(
                     raise ValueError("'bits' attribute is required for 'float' type.")
                 recap_type = FloatType(**type_dict)
             case "string":
-                if "bytes" not in type_dict:
-                    raise ValueError("'bytes' attribute is required for 'string' type.")
-                type_dict["bytes_"] = type_dict.pop("bytes")
+                if "bytes" in type_dict:
+                    type_dict["bytes_"] = type_dict.pop("bytes")
                 recap_type = StringType(**type_dict)
             case "bytes":
-                if "bytes" not in type_dict:
-                    raise ValueError("'bytes' attribute is required for 'bytes' type.")
-                type_dict["bytes_"] = type_dict.pop("bytes")
+                if "bytes" in type_dict:
+                    type_dict["bytes_"] = type_dict.pop("bytes")
                 recap_type = BytesType(**type_dict)
             case "list":
                 if "values" not in type_dict:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -460,3 +460,33 @@ def test_from_dict_with_union_alias():
     assert resolved_type.bits == 64
     assert resolved_type.signed is True
     assert resolved_type.extra_attrs["unit"] == "millisecond"
+
+
+def test_struct_with_string_field_no_bytes_set():
+    input_dict = {
+        "type": "struct",
+        "fields": [
+            {
+                "type": "string",
+            }
+        ],
+    }
+    result = from_dict(input_dict)
+    assert isinstance(result, StructType)
+    assert isinstance(result.fields[0], StringType)
+    assert result.fields[0].bytes_ == 65_536
+
+
+def test_struct_with_bytes_field_no_bytes_set():
+    input_dict = {
+        "type": "struct",
+        "fields": [
+            {
+                "type": "bytes",
+            }
+        ],
+    }
+    result = from_dict(input_dict)
+    assert isinstance(result, StructType)
+    assert isinstance(result.fields[0], BytesType)
+    assert result.fields[0].bytes_ == 65_536


### PR DESCRIPTION
Based on discussions here:

* https://github.com/recap-build/recap/discussions/284

And a draft PR here:

* https://github.com/recap-build/recap/pull/292

I've decided that `string` and `bytes` types should defaulte `byte` length to 64 KiB when users haven't defined them in the concrete syntax tree (the YAML, TOML, JSON, etc).

See the disucssion and PR for more info.