### PR TITLE
Add `to_dict`, `clean_dict`, and `alias_dict` to types.py

### DIFF
--- a/recap/converters/avro.py
+++ b/recap/converters/avro.py
@@ -95,7 +95,7 @@ class AvroConverter:
                 raise ValueError(f"Unsupported Avro schema: {avro_schema}")
 
         if return_type.alias is not None:
-            self.registry.register_alias(return_type.alias, return_type)
+            self.registry.register_alias(return_type)
 
         return return_type
 

--- a/recap/converters/protobuf.py
+++ b/recap/converters/protobuf.py
@@ -109,7 +109,7 @@ class ProtobufConverter:
                 self._parse_enum(element)
 
         struct_type = StructType(fields=fields, alias=message.name)
-        self.registry.register_alias(message.name, struct_type)
+        self.registry.register_alias(struct_type)
         return struct_type
 
     def _parse_field(self, field: Field) -> RecapType:
@@ -219,5 +219,5 @@ class ProtobufConverter:
             if isinstance(element, EnumValue):
                 symbols.append(element.name)
         enum_type = EnumType(symbols=symbols, alias=enum.name)
-        self.registry.register_alias(enum.name, enum_type)
+        self.registry.register_alias(enum_type)
         return enum_type

--- a/tests/unit/converters/test_avro.py
+++ b/tests/unit/converters/test_avro.py
@@ -13,7 +13,6 @@ from recap.types import (
     MapType,
     NullType,
     ProxyType,
-    RecapType,
     StringType,
     StructType,
     UnionType,


### PR DESCRIPTION
Developers can now use `to_dict` to convert a RecapType (abstract syntax tree) to its corresponding dictionary representation (concrete syntax tree).

This feature will allow developers to serialize Recap types to JSON, YAML, TOML, etc.

`clean_dict` is a helper function that removes default values from a dictionary. It also does some minor compaction to make the output more idiomatic (e.g. simple union types are converted to lists).

```
{
    "type": "union",
    "types": [
        {
            "type": "int",
            "alias": None,
            "doc": None,
            "logical": None,
            "bits": 32,
            "signed": true,
        },
    ],
}
```

Becomes `[{ "type": "int", "bits": 32}]`.

`alias_dict` is a helper function that attempts to replace any types that match an alias with the alias name.

```
{
    "type": "int",
    "bits": 32,
    "signed": true,
}
```

And:

```
{
    "type": "int",
    "bits": 32,
}
```

Both become `{"type": "int32"}`.

Closes #289