### PR TITLE
Fix `make_nullable` bugs

### DIFF
--- a/recap/readers/dbapi.py
+++ b/recap/readers/dbapi.py
@@ -4,7 +4,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, List, Protocol, Tuple
 
-from recap.types import NullType, RecapType, StructType, UnionType
+from recap.types import NullType, RecapType, StructType, UnionType, make_nullable
 
 
 class DbapiReader(ABC):
@@ -34,7 +34,7 @@ class DbapiReader(ABC):
             is_nullable = column_props["IS_NULLABLE"].upper() == "YES"
 
             if is_nullable:
-                base_type = UnionType([NullType(), base_type])
+                base_type = make_nullable(base_type)
 
             if column_props["COLUMN_DEFAULT"] is not None or is_nullable:
                 base_type.extra_attrs["default"] = column_props["COLUMN_DEFAULT"]

--- a/recap/types.py
+++ b/recap/types.py
@@ -630,8 +630,16 @@ def alias_dict(
     return type_dict
 
 
-# TODO: Move this to json_schema.py. It's not generic enough.
 def make_nullable(type_: RecapType) -> UnionType:
+    """
+    Make a type nullable by wrapping it in a union with null. Promote the
+    doc and default values to the union.
+
+    :param type_: The type to make nullable.
+    :return: A union type with null and the original type. Doc and default
+        are promoted to the union if they're set.
+    """
+
     RecapTypeClass = type_.__class__
     attrs = vars(type_)
     attrs.pop("type_", None)
@@ -639,11 +647,12 @@ def make_nullable(type_: RecapType) -> UnionType:
     doc = attrs.pop("doc", None)
     # Unnest extra_attrs for copy or we end up with extra_attrs["extra_attrs"]
     extra_attrs = attrs.pop("extra_attrs", {})
+    union_attrs = {
+        "default": extra_attrs.pop("default", None),
+        "doc": doc,
+    }
     type_copy = RecapTypeClass(**attrs, **extra_attrs)
-    union_attrs = {}
-    if default := extra_attrs.get("default"):
-        union_attrs["default"] = default
-    return UnionType([NullType(), type_copy], doc=doc, **union_attrs)
+    return UnionType([NullType(), type_copy], **union_attrs)
 
 
 TYPE_CLASSES = {

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -28,12 +28,30 @@ def test_all_basic_types():
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
-            [NullType(), StringType(bytes_=9_223_372_036_854_775_807)], name="a_string"
+            [NullType(), StringType(bytes_=9_223_372_036_854_775_807)],
+            name="a_string",
+            default=None,
         ),
-        UnionType([NullType(), FloatType(bits=64)], name="a_number"),
-        UnionType([NullType(), IntType(bits=32, signed=True)], name="an_integer"),
-        UnionType([NullType(), BoolType()], name="a_boolean"),
-        UnionType([NullType(), NullType()], name="a_null"),
+        UnionType(
+            [NullType(), FloatType(bits=64)],
+            name="a_number",
+            default=None,
+        ),
+        UnionType(
+            [NullType(), IntType(bits=32, signed=True)],
+            name="an_integer",
+            default=None,
+        ),
+        UnionType(
+            [NullType(), BoolType()],
+            name="a_boolean",
+            default=None,
+        ),
+        UnionType(
+            [NullType(), NullType()],
+            name="a_null",
+            default=None,
+        ),
     ]
 
 
@@ -62,11 +80,13 @@ def test_nested_objects():
                         UnionType(
                             [NullType(), StringType(bytes_=9_223_372_036_854_775_807)],
                             name="a_string",
+                            default=None,
                         ),
                     ],
                 ),
             ],
             name="an_object",
+            default=None,
         ),
     ]
 
@@ -103,12 +123,14 @@ def test_object_with_array_of_objects():
                                     StringType(bytes_=9_223_372_036_854_775_807),
                                 ],
                                 name="a_string",
+                                default=None,
                             )
                         ]
                     ),
                 ),
             ],
             name="an_array",
+            default=None,
         ),
     ]
 
@@ -128,7 +150,11 @@ def test_required_properties():
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         StringType(bytes_=9_223_372_036_854_775_807, name="required_property"),
-        UnionType([NullType(), FloatType(bits=64)], name="optional_property"),
+        UnionType(
+            [NullType(), FloatType(bits=64)],
+            name="optional_property",
+            default=None,
+        ),
     ]
 
 
@@ -151,6 +177,7 @@ def test_doc_attribute():
             [NullType(), StringType(bytes_=9_223_372_036_854_775_807)],
             name="a_string",
             doc="This is a string",
+            default=None,
         ),
     ]
 
@@ -171,7 +198,9 @@ def test_name_attribute():
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
-            [NullType(), StringType(bytes_=9_223_372_036_854_775_807)], name="a_string"
+            [NullType(), StringType(bytes_=9_223_372_036_854_775_807)],
+            name="a_string",
+            default=None,
         ),
     ]
 
@@ -194,7 +223,7 @@ def test_default_attribute():
         UnionType(
             [
                 NullType(),
-                StringType(bytes_=9_223_372_036_854_775_807, default="Default value"),
+                StringType(bytes_=9_223_372_036_854_775_807),
             ],
             name="a_string",
             default="Default value",


### PR DESCRIPTION
`make_nullable` was leaving `default` in the child type and was not setting `default=None` when no default was set.

I fixed this and also updated `DbapiReader` to use `make_nullable`.