### PR TITLE
Move `make_nullable` to RecapType instance method

### DIFF
--- a/recap/converters/json_schema.py
+++ b/recap/converters/json_schema.py
@@ -9,7 +9,6 @@ from recap.types import (
     RecapType,
     StringType,
     StructType,
-    make_nullable,
 )
 
 
@@ -34,7 +33,7 @@ class JSONSchemaConverter:
                 for name, prop in properties.items():
                     field = self._parse(prop)
                     if name not in json_schema.get("required", []):
-                        field = make_nullable(field)
+                        field = field.make_nullable()
                     field.extra_attrs["name"] = name
                     fields.append(field)
                 return StructType(fields, **extra_attrs)

--- a/recap/readers/dbapi.py
+++ b/recap/readers/dbapi.py
@@ -4,7 +4,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, List, Protocol, Tuple
 
-from recap.types import NullType, RecapType, StructType, UnionType, make_nullable
+from recap.types import RecapType, StructType
 
 
 class DbapiReader(ABC):
@@ -34,7 +34,7 @@ class DbapiReader(ABC):
             is_nullable = column_props["IS_NULLABLE"].upper() == "YES"
 
             if is_nullable:
-                base_type = make_nullable(base_type)
+                base_type = base_type.make_nullable()
 
             if column_props["COLUMN_DEFAULT"] is not None or is_nullable:
                 base_type.extra_attrs["default"] = column_props["COLUMN_DEFAULT"]


### PR DESCRIPTION
Some more cleanup and refactoring. I decided to put `make_nullable` into RecapType as an instance method since it's working on a RecapType instance. Seemed to make more sense there.