### PR TITLE
Rename `struct` and `convert` for readers and converters

### DIFF
--- a/recap/converters/avro.py
+++ b/recap/converters/avro.py
@@ -22,7 +22,7 @@ class AvroConverter:
     def __init__(self) -> None:
         self.registry = RecapTypeRegistry()
 
-    def convert(self, avro_schema_str: str) -> StructType:
+    def to_recap(self, avro_schema_str: str) -> StructType:
         avro_schema = json.loads(avro_schema_str)
         recap_schema = self._parse(avro_schema)
         if not isinstance(recap_schema, StructType):

--- a/recap/converters/json_schema.py
+++ b/recap/converters/json_schema.py
@@ -13,7 +13,7 @@ from recap.types import (
 
 
 class JSONSchemaConverter:
-    def convert(self, json_schema_str: str) -> StructType:
+    def to_recap(self, json_schema_str: str) -> StructType:
         json_schema = json.loads(json_schema_str)
         recap_schema = self._parse(json_schema)
         if not isinstance(recap_schema, StructType):

--- a/recap/converters/protobuf.py
+++ b/recap/converters/protobuf.py
@@ -31,7 +31,7 @@ class ProtobufConverter:
     def __init__(self) -> None:
         self.registry = RecapTypeRegistry()
 
-    def convert(self, protobuf_schema_str: str) -> StructType:
+    def to_recap(self, protobuf_schema_str: str) -> StructType:
         file = Parser().parse(protobuf_schema_str)
         root_message = self._parse(file)
         root_message = self._resolve_proxies(root_message)

--- a/recap/readers/confluent_registry.py
+++ b/recap/readers/confluent_registry.py
@@ -14,17 +14,17 @@ class ConfluentRegistryReader:
             else registry
         )
 
-    def struct(self, topic: str) -> StructType:
+    def to_recap(self, topic: str) -> StructType:
         subject = f"{topic}-value"
         registered_schema = self.registry.get_latest_version(subject)
         schema_str = registered_schema.schema.schema_str
         match registered_schema.schema.schema_type:
             case "AVRO":
-                return AvroConverter().convert(schema_str)
+                return AvroConverter().to_recap(schema_str)
             case "JSON":
-                return JSONSchemaConverter().convert(schema_str)
+                return JSONSchemaConverter().to_recap(schema_str)
             case "PROTOBUF":
-                return ProtobufConverter().convert(schema_str)
+                return ProtobufConverter().to_recap(schema_str)
             case _:
                 raise ValueError(
                     f"Unsupported schema type {registered_schema.schema.schema_type}"

--- a/recap/readers/dbapi.py
+++ b/recap/readers/dbapi.py
@@ -11,7 +11,7 @@ class DbapiReader(ABC):
     def __init__(self, connection: Connection) -> None:
         self.connection = connection
 
-    def struct(self, table: str, schema: str, catalog: str) -> StructType:
+    def to_recap(self, table: str, schema: str, catalog: str) -> StructType:
         cursor = self.connection.cursor()
         cursor.execute(
             f"""

--- a/recap/readers/hive_metastore.py
+++ b/recap/readers/hive_metastore.py
@@ -31,7 +31,7 @@ class HiveMetastoreReader:
     def __init__(self, client: HMS):
         self.client = client
 
-    def struct(self, database_name: str, table_name: str) -> StructType:
+    def to_recap(self, database_name: str, table_name: str) -> StructType:
         table = self.client.get_table(database_name, table_name)
         fields = []
         for col in table.columns:

--- a/tests/integration/readers/test_confluent_registry.py
+++ b/tests/integration/readers/test_confluent_registry.py
@@ -65,7 +65,7 @@ class TestConfluentRegistryReader:
 
     def test_struct_avro(self):
         reader = ConfluentRegistryReader(self.schema_registry_client)
-        result = reader.struct("dummy_topic")
+        result = reader.to_recap("dummy_topic")
 
         assert isinstance(result, StructType)
         assert len(result.fields) == 2
@@ -76,7 +76,7 @@ class TestConfluentRegistryReader:
 
     def test_struct_proto(self):
         reader = ConfluentRegistryReader(self.schema_registry_client)
-        result = reader.struct("dummy_topic_protobuf")
+        result = reader.to_recap("dummy_topic_protobuf")
 
         assert isinstance(result, StructType)
         assert len(result.fields) == 2
@@ -89,7 +89,7 @@ class TestConfluentRegistryReader:
 
     def test_struct_json(self):
         reader = ConfluentRegistryReader(self.schema_registry_client)
-        result = reader.struct("dummy_topic_json")
+        result = reader.to_recap("dummy_topic_json")
 
         assert isinstance(result, StructType)
         assert len(result.fields) == 2

--- a/tests/integration/readers/test_hive_metastore.py
+++ b/tests/integration/readers/test_hive_metastore.py
@@ -3,18 +3,6 @@ import os
 import pytest
 from pymetastore.hive_metastore import ttypes
 from pymetastore.hive_metastore.ThriftHiveMetastore import Client
-from pymetastore.htypes import (
-    HCharType,
-    HDecimalType,
-    HListType,
-    HMapType,
-    HPrimitiveType,
-    HStructType,
-    HType,
-    HTypeCategory,
-    HUnionType,
-    HVarcharType,
-)
 from pymetastore.metastore import HMS
 from thrift.protocol import TBinaryProtocol
 from thrift.transport import TSocket, TTransport
@@ -28,7 +16,6 @@ from recap.types import (
     ListType,
     MapType,
     NullType,
-    RecapType,
     StringType,
     StructType,
     UnionType,
@@ -164,7 +151,7 @@ def setup_data(hive_client):
 def test_primitive_types(hive_client):
     hms = HMS(hive_client)
     reader = HiveMetastoreReader(hms)
-    table = reader.struct("test_db", "test_table2")
+    table = reader.to_recap("test_db", "test_table2")
     fields = table.fields
 
     assert len(fields) == 13
@@ -272,7 +259,7 @@ def test_primitive_types(hive_client):
 def test_parameterized_types(hive_client):
     hms = HMS(hive_client)
     reader = HiveMetastoreReader(hms)
-    table = reader.struct("test_db", "test_table3")
+    table = reader.to_recap("test_db", "test_table3")
     fields = table.fields
 
     assert len(fields) == 7

--- a/tests/integration/readers/test_postgresql.py
+++ b/tests/integration/readers/test_postgresql.py
@@ -65,7 +65,7 @@ class TestPostgresqlReader:
         reader = PostgresqlReader(self.connection)  # type: ignore
 
         # Test 'test_types' table
-        test_types_struct = reader.struct("test_types", "public", "testdb")
+        test_types_struct = reader.to_recap("test_types", "public", "testdb")
 
         # Define the expected output for 'test_types' table
         expected_fields = [

--- a/tests/unit/converters/test_avro.py
+++ b/tests/unit/converters/test_avro.py
@@ -53,7 +53,7 @@ def test_enum():
             }
         ],
     }
-    actual = converter.convert(json.dumps(avro_enum))
+    actual = converter.to_recap(json.dumps(avro_enum))
 
     enum_type = EnumType(symbols=["RED", "GREEN", "BLUE"], name="color", alias="Color")
     expected = StructType(fields=[enum_type], alias="TestEnum")
@@ -68,7 +68,7 @@ def test_array():
         "name": "TestArray",
         "fields": [{"name": "items", "type": {"type": "array", "items": "string"}}],
     }
-    actual = converter.convert(json.dumps(avro_array))
+    actual = converter.to_recap(json.dumps(avro_array))
 
     array_type = ListType(name="items", values=StringType(9_223_372_036_854_775_807))
     expected = StructType(fields=[array_type], alias="TestArray")
@@ -83,7 +83,7 @@ def test_map():
         "name": "TestMap",
         "fields": [{"name": "values", "type": {"type": "map", "values": "int"}}],
     }
-    actual = converter.convert(json.dumps(avro_map))
+    actual = converter.to_recap(json.dumps(avro_map))
 
     # Construct an expected Map RecapType instance
     map_type = MapType(
@@ -108,7 +108,7 @@ def test_union():
             }
         ],
     }
-    actual = converter.convert(json.dumps(avro_union))
+    actual = converter.to_recap(json.dumps(avro_union))
 
     # Construct an expected Union RecapType instance
     union_type = UnionType(
@@ -129,7 +129,7 @@ def test_record():
             {"name": "b", "type": "string"},
         ],
     }
-    actual = converter.convert(json.dumps(avro_record))
+    actual = converter.to_recap(json.dumps(avro_record))
     assert isinstance(actual, StructType)
     assert len(actual.fields) == 2
     assert isinstance(actual.fields[0], IntType)
@@ -158,7 +158,7 @@ def test_self_referencing():
     # The expected schema is a recursive structure, so we can't create it
     # directly as Python would run into an infinite recursion. We can only
     # check that the resulting structure has the expected properties.
-    actual = converter.convert(json.dumps(avro_schema))
+    actual = converter.to_recap(json.dumps(avro_schema))
 
     assert isinstance(actual, StructType)
     assert len(actual.fields) == 2
@@ -188,7 +188,7 @@ def test_record_with_docs_and_default():
         ],
     }
 
-    actual = converter.convert(json.dumps(avro_schema))
+    actual = converter.to_recap(json.dumps(avro_schema))
 
     assert isinstance(actual, StructType)
     assert len(actual.fields) == 2
@@ -218,7 +218,7 @@ def test_decimal():
             }
         ],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, BytesType)
     assert field.logical == "build.recap.Decimal"
@@ -243,7 +243,7 @@ def test_uuid():
         "name": "test_uuid",
         "fields": [{"name": "uuid", "type": {"type": "string", "logicalType": "uuid"}}],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, StringType)
     assert field.logical == "build.recap.UUID"
@@ -258,7 +258,7 @@ def test_date():
         "name": "test_date",
         "fields": [{"name": "date", "type": {"type": "int", "logicalType": "date"}}],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, IntType)
     assert field.logical == "build.recap.Date"
@@ -276,7 +276,7 @@ def test_time_millis():
             {"name": "time", "type": {"type": "int", "logicalType": "time-millis"}}
         ],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, IntType)
     assert field.logical == "build.recap.Time"
@@ -294,7 +294,7 @@ def test_time_micros():
             {"name": "time", "type": {"type": "long", "logicalType": "time-micros"}}
         ],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, IntType)
     assert field.logical == "build.recap.Time"
@@ -315,7 +315,7 @@ def test_timestamp_millis():
             }
         ],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, IntType)
     assert field.logical == "build.recap.Timestamp"
@@ -337,7 +337,7 @@ def test_timestamp_micros():
             }
         ],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, IntType)
     assert field.logical == "build.recap.Timestamp"
@@ -359,7 +359,7 @@ def test_duration():
             }
         ],
     }
-    schema = converter.convert(json.dumps(avro_schema))
+    schema = converter.to_recap(json.dumps(avro_schema))
     field = schema.fields[0]
     assert isinstance(field, BytesType)
     assert field.logical == "build.recap.Interval"

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -24,7 +24,7 @@ def test_all_basic_types():
         }
     }
     """
-    struct_type = JSONSchemaConverter().convert(json_schema)
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
@@ -69,7 +69,7 @@ def test_nested_objects():
         }
     }
     """
-    struct_type = JSONSchemaConverter().convert(json_schema)
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
@@ -108,7 +108,7 @@ def test_object_with_array_of_objects():
         }
     }
     """
-    struct_type = JSONSchemaConverter().convert(json_schema)
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
@@ -146,7 +146,7 @@ def test_required_properties():
         "required": ["required_property"]
     }
     """
-    struct_type = JSONSchemaConverter().convert(json_schema)
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         StringType(bytes_=9_223_372_036_854_775_807, name="required_property"),
@@ -170,7 +170,7 @@ def test_doc_attribute():
         }
     }
     """
-    struct_type = JSONSchemaConverter().convert(json_schema)
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
@@ -194,7 +194,7 @@ def test_name_attribute():
         }
     }
     """
-    struct_type = JSONSchemaConverter().convert(json_schema)
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
@@ -217,7 +217,7 @@ def test_default_attribute():
         }
     }
     """
-    struct_type = JSONSchemaConverter().convert(json_schema)
+    struct_type = JSONSchemaConverter().to_recap(json_schema)
     assert isinstance(struct_type, StructType)
     assert struct_type.fields == [
         UnionType(
@@ -245,7 +245,7 @@ def test_convert_date():
         "required": ["date"]
     }
     """
-    result = converter.convert(schema)
+    result = converter.to_recap(schema)
     assert isinstance(result, StructType)
     assert isinstance(result.fields[0], StringType)
     assert result.fields[0].logical == "org.iso.8601.Date"
@@ -265,7 +265,7 @@ def test_convert_datetime():
         "required": ["datetime"]
     }
     """
-    result = converter.convert(schema)
+    result = converter.to_recap(schema)
     assert isinstance(result, StructType)
     assert isinstance(result.fields[0], StringType)
     assert result.fields[0].logical == "org.iso.8601.DateTime"
@@ -285,7 +285,7 @@ def test_convert_time():
         "required": ["time"]
     }
     """
-    result = converter.convert(schema)
+    result = converter.to_recap(schema)
     assert isinstance(result, StructType)
     assert isinstance(result.fields[0], StringType)
     assert result.fields[0].logical == "org.iso.8601.Time"

--- a/tests/unit/converters/test_protobuf.py
+++ b/tests/unit/converters/test_protobuf.py
@@ -35,7 +35,7 @@ def test_protobuf_converter():
         sfixed64 large_sfixed_id = 15;
     }
     """
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 15
@@ -150,7 +150,7 @@ def test_protobuf_converter_repeated():
         }
     """
 
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -171,7 +171,7 @@ def test_protobuf_converter_map():
         }
     """
 
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -200,7 +200,7 @@ def test_protobuf_converter_forward_reference():
         }
     """
 
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -229,7 +229,7 @@ def test_protobuf_converter_nested_message():
         }
     """
 
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -261,7 +261,7 @@ def test_protobuf_converter_enum():
         }
     """
 
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -281,7 +281,7 @@ def test_protobuf_converter_oneof():
         }
     """
 
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -319,7 +319,7 @@ def test_protobuf_converter_doubly_nested_message():
         }
     """
 
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -351,7 +351,7 @@ def test_protobuf_converter_timestamp():
         google.protobuf.Timestamp timestamp = 1;
     }
     """
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -374,7 +374,7 @@ def test_protobuf_converter_duration():
         google.protobuf.Duration duration = 1;
     }
     """
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1
@@ -395,7 +395,7 @@ def test_protobuf_converter_nullvalue():
         google.protobuf.NullValue null_value = 1;
     }
     """
-    recap_schema = ProtobufConverter().convert(protobuf_schema)
+    recap_schema = ProtobufConverter().to_recap(protobuf_schema)
     assert isinstance(recap_schema, StructType)
     fields = recap_schema.fields
     assert len(fields) == 1

--- a/tests/unit/readers/test_confluent_registry.py
+++ b/tests/unit/readers/test_confluent_registry.py
@@ -28,7 +28,7 @@ def test_struct_avro():
     mock_schema_registry_client.get_latest_version.return_value = MockRegisteredSchema()
 
     reader = ConfluentRegistryReader(mock_schema_registry_client)
-    result = reader.struct("dummy_topic")
+    result = reader.to_recap("dummy_topic")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -64,7 +64,7 @@ def test_struct_protobuf():
     mock_schema_registry_client.get_latest_version.return_value = MockRegisteredSchema()
 
     reader = ConfluentRegistryReader(mock_schema_registry_client)
-    result = reader.struct("dummy_topic")
+    result = reader.to_recap("dummy_topic")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -108,7 +108,7 @@ def test_struct_json_schema():
     mock_schema_registry_client.get_latest_version.return_value = MockRegisteredSchema()
 
     reader = ConfluentRegistryReader(mock_schema_registry_client)
-    result = reader.struct("dummy_topic")
+    result = reader.to_recap("dummy_topic")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)

--- a/tests/unit/readers/test_hive_metastore.py
+++ b/tests/unit/readers/test_hive_metastore.py
@@ -52,7 +52,7 @@ def test_struct():
     mock_client.get_table.return_value = MockTable
 
     reader = HiveMetastoreReader(mock_client)
-    result = reader.struct("dummy_database", "dummy_table")
+    result = reader.to_recap("dummy_database", "dummy_table")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -146,7 +146,7 @@ def test_struct_with_struct_type():
     mock_client.get_table.return_value = MockTable
 
     reader = HiveMetastoreReader(mock_client)
-    result = reader.struct("dummy_database", "dummy_table")
+    result = reader.to_recap("dummy_database", "dummy_table")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -185,7 +185,7 @@ def test_struct_with_list_type():
     mock_client.get_table.return_value = MockTable
 
     reader = HiveMetastoreReader(mock_client)
-    result = reader.struct("dummy_database", "dummy_table")
+    result = reader.to_recap("dummy_database", "dummy_table")
 
     assert isinstance(result, StructType)
     assert len(result.fields) == 1
@@ -214,7 +214,7 @@ def test_struct_with_map_type():
     mock_client.get_table.return_value = MockTable
 
     reader = HiveMetastoreReader(mock_client)
-    result = reader.struct("dummy_database", "dummy_table")
+    result = reader.to_recap("dummy_database", "dummy_table")
 
     assert isinstance(result, StructType)
     assert len(result.fields) == 1
@@ -254,7 +254,7 @@ def test_struct_with_nested_struct_type():
     mock_client.get_table.return_value = MockTable
 
     reader = HiveMetastoreReader(mock_client)
-    result = reader.struct("dummy_database", "dummy_table")
+    result = reader.to_recap("dummy_database", "dummy_table")
 
     # Check that the schema was converted correctly.
     assert isinstance(result, StructType)
@@ -314,7 +314,7 @@ def test_struct_with_union_type():
     mock_client.get_table.return_value = MockTable
 
     reader = HiveMetastoreReader(mock_client)
-    result = reader.struct("dummy_database", "dummy_table")
+    result = reader.to_recap("dummy_database", "dummy_table")
 
     assert isinstance(result, StructType)
     assert len(result.fields) == 1

--- a/tests/unit/readers/test_snowflake.py
+++ b/tests/unit/readers/test_snowflake.py
@@ -73,7 +73,7 @@ class TestSnowflakeReader:
         reader = SnowflakeReader(self.connection)  # type: ignore
 
         # Test 'test_types' table
-        test_types_struct = reader.struct("TEST_TYPES", "PUBLIC", "TESTDB")
+        test_types_struct = reader.to_recap("TEST_TYPES", "PUBLIC", "TESTDB")
 
         # Define the expected output for 'test_types' table
         expected_fields = [


### PR DESCRIPTION
I'm prepping to write converters from RecapTypes to Avro, Protobuf, and JSON. To make things clearer, I've renamed `struct` and `convert` to `to_recap` to make it more explicit. I'll add a `from_recap` for each of the converters next.