### PR TITLE
Add `alias` support for `AvroConverter.from_recap`

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -305,11 +305,16 @@ class RecapTypeRegistry:
         }
 
     def register_alias(self, recap_type: RecapType):
-        if recap_type.alias is None:
+        alias = recap_type.alias
+        if alias is None:
             raise ValueError("RecapType must have an alias.")
-        if recap_type.alias in self._type_registry:
+        if alias in self._type_registry:
             raise ValueError(f"Alias {recap_type.alias} is already used.")
-        self._type_registry[recap_type.alias] = recap_type
+        recap_type = copy.deepcopy(recap_type)
+        # Registry contains types without aliases so aliased types don't get
+        # accidentally redefined when referenced.
+        recap_type.alias = None
+        self._type_registry[alias] = recap_type
 
     def from_alias(self, alias: str) -> RecapType:
         try:

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -199,23 +199,26 @@ def test_from_dict_self_referencing_structure():
     # define the test_dict with the self-referencing structure
     test_dict = {
         "type": "struct",
-        "fields": [{"type": "int", "bits": 32}, {"type": "self_reference"}],
-        "alias": "self_reference",
+        "fields": [
+            {"type": "int", "bits": 32},
+            {"type": "build.recap.SelfReferencingStructure"},
+        ],
+        "alias": "build.recap.SelfReferencingStructure",
     }
 
     # Create a self-referencing RecapType
     recap_type = from_dict(test_dict)
     assert isinstance(recap_type, StructType)
     assert recap_type.type_ == "struct"
-    for field in recap_type.fields:
-        if isinstance(field, IntType):
-            assert field.type_ == "int"
-            assert field.bits == 32
-        elif isinstance(field, ProxyType):
-            assert field.type_ == "proxy"
-            assert field.alias == "self_reference"
-            # Resolve the ProxyType and check it equals the original RecapType
-            assert field.resolve() == recap_type
+    assert len(recap_type.fields) == 2
+    if isinstance(recap_type.fields[0], IntType):
+        assert recap_type.fields[0].type_ == "int"
+        assert recap_type.fields[0].bits == 32
+    elif isinstance(recap_type.fields[1], ProxyType):
+        assert recap_type.fields[1].type_ == "proxy"
+        assert recap_type.fields[1].alias == "build.recap.SelfReferencingStructure"
+        # Resolve the ProxyType and check it equals the original RecapType
+        assert recap_type.fields[1].resolve() == recap_type
 
 
 def test_from_dict_alias_with_attribute_override():


### PR DESCRIPTION
RecapTypes that include ProxyType can now be converted to Avro.

Built-in aliases (int32, decimal256) are fully resolved rather than treated as aliases.

```
{"type": "int32"}
```

Converts to Avro as:

```
{"type": "int"}
```

But fully qualified aliases are converted to Avro `aliases` values.

```
{"type": "int", "bits": 32, "alias": "build.recap.Int32Thing"}
```

Converts to Avro as:

```
{"type": "int", "aliases": ["build.recap.Int32Thing"]}
```

Closes #305