### PR TITLE
Add `fixed` type for `to_recap` in AvroConverter

### DIFF
--- a/recap/converters/avro.py
+++ b/recap/converters/avro.py
@@ -294,6 +294,15 @@ class AvroConverter:
                     alias=alias,
                     **extra_attrs,
                 )
+            case {
+                "type": "fixed",
+                "size": int(size),
+            } if size <= 9_223_372_036_854_775_807:
+                return_type = BytesType(
+                    size,
+                    alias=alias,
+                    **extra_attrs,
+                )
             case {"type": "string"}:
                 return_type = StringType(
                     9_223_372_036_854_775_807,

--- a/tests/unit/converters/test_avro.py
+++ b/tests/unit/converters/test_avro.py
@@ -38,6 +38,34 @@ def test_to_recap_parse_primitives():
         assert converter._parse(avro_type, "_root") == recap_type
 
 
+def test_to_recap_fixed():
+    converter = AvroConverter()
+    avro_enum = {
+        "type": "record",
+        "name": "TestEnum",
+        "fields": [
+            {
+                "name": "fixed_field",
+                "type": {
+                    "type": "fixed",
+                    "name": "MD5",
+                    "size": 16,
+                },
+            }
+        ],
+    }
+    actual = converter.to_recap(json.dumps(avro_enum))
+
+    fixed_type = BytesType(
+        bytes_=16,
+        name="fixed_field",
+        alias="_root.MD5",
+    )
+    expected = StructType(fields=[fixed_type], name="TestEnum", alias="_root.TestEnum")
+
+    assert actual == expected
+
+
 def test_to_recap_enum():
     converter = AvroConverter()
     avro_enum = {


### PR DESCRIPTION
I noticed AvroConverter was missing `fixed` support for `to_recap`. Fixing that.

Closes #309