### PR TITLE
Add BigQueryReader.to_recap

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
     - name: Test with pytest
       run: |
         source venv/bin/activate
-        pdm run pytest tests/unit
+        pdm run pytest tests/unit -vv
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -73,6 +73,15 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
+      # TODO Waiting on https://github.com/goccy/bigquery-emulator/pull/208
+      bigquery:
+        image: ghcr.io/criccomini/bigquery-emulator:0.4.3-envvar
+        env:
+          BIGQUERY_EMULATOR_PROJECT: test_project
+          BIGQUERY_EMULATOR_DATASET: test_dataset
+        ports:
+          - 9050:9050
 
       zookeeper:
         image: confluentinc/cp-zookeeper:latest
@@ -142,4 +151,4 @@ jobs:
     - name: Test with pytest
       run: |
         source venv/bin/activate
-        pdm run pytest tests/integration
+        pdm run pytest tests/integration -vv

--- a/pdm.lock
+++ b/pdm.lock
@@ -38,6 +38,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cachetools"
+version = "5.3.1"
+requires_python = ">=3.7"
+summary = "Extensible memoizing collections and decorators"
+
+[[package]]
 name = "certifi"
 version = "2023.5.7"
 requires_python = ">=3.6"
@@ -132,6 +138,114 @@ requires_python = ">=3.7"
 summary = "A platform independent file lock."
 
 [[package]]
+name = "google-api-core"
+version = "2.11.1"
+requires_python = ">=3.7"
+summary = "Google API client core library"
+dependencies = [
+    "google-auth<3.0.dev0,>=2.14.1",
+    "googleapis-common-protos<2.0.dev0,>=1.56.2",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5",
+    "requests<3.0.0.dev0,>=2.18.0",
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.11.1"
+extras = ["grpc"]
+requires_python = ">=3.7"
+summary = "Google API client core library"
+dependencies = [
+    "google-api-core==2.11.1",
+    "grpcio-status<2.0.dev0,>=1.33.2",
+    "grpcio-status<2.0.dev0,>=1.49.1; python_version >= \"3.11\"",
+    "grpcio<2.0dev,>=1.33.2",
+    "grpcio<2.0dev,>=1.49.1; python_version >= \"3.11\"",
+]
+
+[[package]]
+name = "google-auth"
+version = "2.22.0"
+requires_python = ">=3.6"
+summary = "Google Authentication Library"
+dependencies = [
+    "cachetools<6.0,>=2.0.0",
+    "pyasn1-modules>=0.2.1",
+    "rsa<5,>=3.1.4",
+    "six>=1.9.0",
+    "urllib3<2.0",
+]
+
+[[package]]
+name = "google-cloud-bigquery"
+version = "3.11.3"
+requires_python = ">=3.7"
+summary = "Google BigQuery API client library"
+dependencies = [
+    "google-api-core[grpc]!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev,>=1.31.5",
+    "google-cloud-core<3.0.0dev,>=1.6.0",
+    "google-resumable-media<3.0dev,>=0.6.0",
+    "grpcio<2.0dev,>=1.47.0",
+    "grpcio<2.0dev,>=1.49.1; python_version >= \"3.11\"",
+    "packaging>=20.0.0",
+    "proto-plus<2.0.0dev,>=1.15.0",
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0dev,>=3.19.5",
+    "python-dateutil<3.0dev,>=2.7.2",
+    "requests<3.0.0dev,>=2.21.0",
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.3.3"
+requires_python = ">=3.7"
+summary = "Google Cloud API client core library"
+dependencies = [
+    "google-api-core!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.0,<3.0.0dev,>=1.31.6",
+    "google-auth<3.0dev,>=1.25.0",
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.5.0"
+requires_python = ">=3.7"
+summary = "A python wrapper of the C library 'Google CRC32C'"
+
+[[package]]
+name = "google-resumable-media"
+version = "2.5.0"
+requires_python = ">= 3.7"
+summary = "Utilities for Google Media Downloads and Resumable Uploads"
+dependencies = [
+    "google-crc32c<2.0dev,>=1.0",
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.59.1"
+requires_python = ">=3.7"
+summary = "Common protobufs used in Google APIs"
+dependencies = [
+    "protobuf!=3.20.0,!=3.20.1,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5,<5.0.0.dev0,>=3.19.5",
+]
+
+[[package]]
+name = "grpcio"
+version = "1.56.0"
+requires_python = ">=3.7"
+summary = "HTTP/2-based RPC framework"
+
+[[package]]
+name = "grpcio-status"
+version = "1.56.0"
+requires_python = ">=3.6"
+summary = "Status proto mapping for gRPC"
+dependencies = [
+    "googleapis-common-protos>=1.5.5",
+    "grpcio>=1.56.0",
+    "protobuf>=4.21.6",
+]
+
+[[package]]
 name = "idna"
 version = "3.4"
 requires_python = ">=3.5"
@@ -215,6 +329,15 @@ requires_python = ">=3.6"
 summary = "plugin and hook calling mechanisms for python"
 
 [[package]]
+name = "proto-plus"
+version = "1.22.3"
+requires_python = ">=3.6"
+summary = "Beautiful, Pythonic protocol buffers."
+dependencies = [
+    "protobuf<5.0.0dev,>=3.19.0",
+]
+
+[[package]]
 name = "proto-schema-parser"
 version = "0.3.0"
 requires_python = ">=3.8"
@@ -222,6 +345,12 @@ summary = "A Pure Python Protobuf 3 .proto Parser"
 dependencies = [
     "antlr4-python3-runtime>=4.13.0",
 ]
+
+[[package]]
+name = "protobuf"
+version = "4.23.4"
+requires_python = ">=3.7"
+summary = ""
 
 [[package]]
 name = "psycopg2-binary"
@@ -236,6 +365,21 @@ requires_python = ">=3.7"
 summary = "Python library for Apache Arrow"
 dependencies = [
     "numpy>=1.16.6",
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.5.0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+summary = "Pure-Python implementation of ASN.1 types and DER/BER/CER codecs (X.208)"
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.3.0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
+summary = "A collection of ASN.1-based protocols modules"
+dependencies = [
+    "pyasn1<0.6.0,>=0.4.6",
 ]
 
 [[package]]
@@ -315,6 +459,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+summary = "Extensions to the standard Python datetime module"
+dependencies = [
+    "six>=1.5",
+]
+
+[[package]]
 name = "pytz"
 version = "2023.3"
 summary = "World timezone definitions, modern and historical"
@@ -329,6 +482,15 @@ dependencies = [
     "charset-normalizer<4,>=2",
     "idna<4,>=2.5",
     "urllib3<3,>=1.21.1",
+]
+
+[[package]]
+name = "rsa"
+version = "4.9"
+requires_python = ">=3.6,<4"
+summary = "Pure-Python RSA implementation"
+dependencies = [
+    "pyasn1>=0.1.3",
 ]
 
 [[package]]
@@ -419,8 +581,8 @@ summary = "Module for decorators, wrappers and monkey patching."
 [metadata]
 lock_version = "4.2"
 cross_platform = true
-groups = ["default", "hive", "kafka", "proto", "style", "tests"]
-content_hash = "sha256:bdc1d6b34e3249a2b58cb691cd6a2dd99eb2808a61f2448368b625ad7e149557"
+groups = ["default", "bigquery", "hive", "kafka", "proto", "style", "tests"]
+content_hash = "sha256:3a583259af3de28bc810ce20b1d105033c49bf9fd3fa2cde0246995865c08fbd"
 
 [metadata.files]
 "antlr4-python3-runtime 4.13.0" = [
@@ -461,6 +623,10 @@ content_hash = "sha256:bdc1d6b34e3249a2b58cb691cd6a2dd99eb2808a61f2448368b625ad7
     {url = "https://files.pythonhosted.org/packages/de/b4/76f152c5eb0be5471c22cd18380d31d188930377a1a57969073b89d6615d/black-23.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:35d1381d7a22cc5b2be2f72c7dfdae4072a3336060635718cc7e1ede24221d6c"},
     {url = "https://files.pythonhosted.org/packages/eb/a5/17b40bfd9b607b69fa726b0b3a473d14b093dcd5191ea1a1dd664eccfee3/black-23.3.0-cp311-cp311-macosx_10_16_universal2.whl", hash = "sha256:c7ab5790333c448903c4b721b59c0d80b11fe5e9803d8703e84dcb8da56fec1b"},
     {url = "https://files.pythonhosted.org/packages/fd/5b/fc2d7922c1a6bb49458d424b5be71d251f2d0dc97be9534e35d171bdc653/black-23.3.0-cp39-cp39-macosx_10_16_universal2.whl", hash = "sha256:f0bd2f4a58d6666500542b26354978218a9babcdc972722f4bf90779524515f3"},
+]
+"cachetools 5.3.1" = [
+    {url = "https://files.pythonhosted.org/packages/9d/8b/8e2ebf5ee26c21504de5ea2fb29cc6ae612b35fd05f959cdb641feb94ec4/cachetools-5.3.1.tar.gz", hash = "sha256:dce83f2d9b4e1f732a8cd44af8e8fab2dbe46201467fc98b3ef8f269092bf62b"},
+    {url = "https://files.pythonhosted.org/packages/a9/c9/c8a7710f2cedcb1db9224fdd4d8307c9e48cbddc46c18b515fefc0f1abbe/cachetools-5.3.1-py3-none-any.whl", hash = "sha256:95ef631eeaea14ba2e36f06437f36463aac3a096799e876ee55e5cdccb102590"},
 ]
 "certifi 2023.5.7" = [
     {url = "https://files.pythonhosted.org/packages/93/71/752f7a4dd4c20d6b12341ed1732368546bc0ca9866139fe812f6009d9ac7/certifi-2023.5.7.tar.gz", hash = "sha256:0f0d56dc5a6ad56fd4ba36484d6cc34451e1c6548c61daad8c320169f91eddc7"},
@@ -739,6 +905,151 @@ content_hash = "sha256:bdc1d6b34e3249a2b58cb691cd6a2dd99eb2808a61f2448368b625ad7
     {url = "https://files.pythonhosted.org/packages/00/0b/c506e9e44e4c4b6c89fcecda23dc115bf8e7ff7eb127e0cb9c114cbc9a15/filelock-3.12.2.tar.gz", hash = "sha256:002740518d8aa59a26b0c76e10fb8c6e15eae825d34b6fdf670333fd7b938d81"},
     {url = "https://files.pythonhosted.org/packages/00/45/ec3407adf6f6b5bf867a4462b2b0af27597a26bd3cd6e2534cb6ab029938/filelock-3.12.2-py3-none-any.whl", hash = "sha256:cbb791cdea2a72f23da6ac5b5269ab0a0d161e9ef0100e653b69049a7706d1ec"},
 ]
+"google-api-core 2.11.1" = [
+    {url = "https://files.pythonhosted.org/packages/6e/c4/c3cd048b6cbeba8d9ae50dd7643ac065b85237338aa7501b0efae91eb4d9/google_api_core-2.11.1-py3-none-any.whl", hash = "sha256:d92a5a92dc36dd4f4b9ee4e55528a90e432b059f93aee6ad857f9de8cc7ae94a"},
+    {url = "https://files.pythonhosted.org/packages/f3/b8/f727ada5b63aba53848e3791dd57be7481d5c9bf86978600ca9cca4ab03e/google-api-core-2.11.1.tar.gz", hash = "sha256:25d29e05a0058ed5f19c61c0a78b1b53adea4d9364b464d014fbda941f6d1c9a"},
+]
+"google-auth 2.22.0" = [
+    {url = "https://files.pythonhosted.org/packages/9c/8d/bff87fc722553a5691d8514da5523c23547f3894189ba03b57592e37bdc2/google_auth-2.22.0-py2.py3-none-any.whl", hash = "sha256:d61d1b40897407b574da67da1a833bdc10d5a11642566e506565d1b1a46ba873"},
+    {url = "https://files.pythonhosted.org/packages/a4/3a/b6ab1073d2ac98c1b4f9036a4d37d5720f783bd4dc6e2c0ae516d3b13326/google-auth-2.22.0.tar.gz", hash = "sha256:164cba9af4e6e4e40c3a4f90a1a6c12ee56f14c0b4868d1ca91b32826ab334ce"},
+]
+"google-cloud-bigquery 3.11.3" = [
+    {url = "https://files.pythonhosted.org/packages/3c/8b/27222eb7bbb0cc38a91b67eeedb2a40e319488004c4d97ac4cb49a56e0ee/google-cloud-bigquery-3.11.3.tar.gz", hash = "sha256:d4585be9e76c984ec83ef290ebeff17562d2c9f2f4f84d3015d9b7b27b499a9d"},
+    {url = "https://files.pythonhosted.org/packages/8e/74/7150922507507e3a802e83585b1ebba918243e4d83e194abebbed6dd9611/google_cloud_bigquery-3.11.3-py2.py3-none-any.whl", hash = "sha256:266ba1ddd213b2454c1e4a92ae647813b783128078eb48dda4c0b443c5057e29"},
+]
+"google-cloud-core 2.3.3" = [
+    {url = "https://files.pythonhosted.org/packages/6b/60/dcc26e42d3754ac57c51a524f53c988f2aa755faec4cc00a232bb0077637/google-cloud-core-2.3.3.tar.gz", hash = "sha256:37b80273c8d7eee1ae816b3a20ae43585ea50506cb0e60f3cf5be5f87f1373cb"},
+    {url = "https://files.pythonhosted.org/packages/a2/40/02045f776fdb6e44194f34b6375a26ce8a61bd9bd03cd8930ed91cf51a62/google_cloud_core-2.3.3-py2.py3-none-any.whl", hash = "sha256:fbd11cad3e98a7e5b0343dc07cb1039a5ffd7a5bb96e1f1e27cee4bda4a90863"},
+]
+"google-crc32c 1.5.0" = [
+    {url = "https://files.pythonhosted.org/packages/02/94/d2ea867760d5a27b3e9eb40ff31faf7f03f949e51d4e3b3ae24f759b5963/google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:72218785ce41b9cfd2fc1d6a017dc1ff7acfc4c17d01053265c41a2c0cc39b8c"},
+    {url = "https://files.pythonhosted.org/packages/08/05/f143e453787b05958a53b226f4f0e1d11ee2d6765c15b24b9ab9d0271875/google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8667b48e7a7ef66afba2c81e1094ef526388d35b873966d8a9a447974ed9178"},
+    {url = "https://files.pythonhosted.org/packages/08/08/ee1c27ac7120c599bb51e09c5bfc3be618cedf34f73b21d0a6455f81f236/google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:272d3892a1e1a2dbc39cc5cde96834c236d5327e2122d3aaa19f6614531bb6eb"},
+    {url = "https://files.pythonhosted.org/packages/0c/1d/5e1eda168f85452609873fc8c0c4e85e0b8a19958e81e5b4bfc681ca3879/google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9ba053c5f50430a3fcfd36f75aff9caeba0440b2d076afdb79a318d6ca245f88"},
+    {url = "https://files.pythonhosted.org/packages/0e/9a/c43c9e80d65c5e004569047e3cc5e851c9e283c47381e8472028bf025590/google_crc32c-1.5.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:c672d99a345849301784604bfeaeba4db0c7aae50b95be04dd651fd2a7310b93"},
+    {url = "https://files.pythonhosted.org/packages/0f/99/e7e288f1b50baf4964ff39fa79d9259d004ae44db35c8280ff4ffea362d5/google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:f583edb943cf2e09c60441b910d6a20b4d9d626c75a36c8fcac01a6c96c01183"},
+    {url = "https://files.pythonhosted.org/packages/13/6f/3ac9e55162d6f40b5893afc796b44624cf76c64aea63bea4ba52ff4f5f39/google_crc32c-1.5.0-cp37-cp37m-win32.whl", hash = "sha256:d3515f198eaa2f0ed49f8819d5732d70698c3fa37384146079b3799b97667a94"},
+    {url = "https://files.pythonhosted.org/packages/1c/8f/f3c495b77d8c50e4d1926c50844d36f46216973694f795b0d73bbc322f97/google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:8b87e1a59c38f275c0e3676fc2ab6d59eccecfd460be267ac360cc31f7bcde96"},
+    {url = "https://files.pythonhosted.org/packages/1d/f2/d2933d57f31a637af3e9e3c9671aed25b888991335bac8db2d492422f1c2/google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4c6fdd4fccbec90cc8a01fc00773fcd5fa28db683c116ee3cb35cd5da9ef6c37"},
+    {url = "https://files.pythonhosted.org/packages/1e/48/f06dd28f26bf7b0b33aeca91a6d7379953e2692081e63351cb4c6ac5fdda/google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84e6e8cd997930fc66d5bb4fde61e2b62ba19d62b7abd7a69920406f9ecca946"},
+    {url = "https://files.pythonhosted.org/packages/1e/a2/b1de9a4f22fdd4ad34e084555a4a34da430ee69a47b71fff23f3309d6abf/google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e1674e4307fa3024fc897ca774e9c7562c957af85df55efe2988ed9056dc4e57"},
+    {url = "https://files.pythonhosted.org/packages/1f/6b/fcd4744a020fa7bfb1a451b0be22b3e5a4cb28bafaaf01467d2e9402b96b/google_crc32c-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:07eb3c611ce363c51a933bf6bd7f8e3878a51d124acfc89452a75120bc436289"},
+    {url = "https://files.pythonhosted.org/packages/23/f8/a6e6304484d72a53c80bbcbe2225c29dfe5cbe17aa1d45ed5c906929025b/google_crc32c-1.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:c6c777a480337ac14f38564ac88ae82d4cd238bf293f0a22295b66eb89ffced7"},
+    {url = "https://files.pythonhosted.org/packages/24/f0/1ef67cfe874a569d309d5aa8bf4004e22257034fc00d7657a9dac0370373/google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:3359fc442a743e870f4588fcf5dcbc1bf929df1fad8fb9905cd94e5edb02e84c"},
+    {url = "https://files.pythonhosted.org/packages/29/93/0934093fbd214ac9d45dce8306e8a1d4b1da83b1d8392caa3e52d3e4c90b/google_crc32c-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:a2355cba1f4ad8b6988a4ca3feed5bff33f6af2d7f134852cf279c2aebfde541"},
+    {url = "https://files.pythonhosted.org/packages/2c/8d/8eb582e052b2c588111f1d697847cf2409bb6e6d8eed8e5b6e3a70db0218/google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02c65b9817512edc6a4ae7c7e987fea799d2e0ee40c53ec573a692bee24de876"},
+    {url = "https://files.pythonhosted.org/packages/34/c6/27be6fc6cbfebff08f63c2017fe885932b3387b45a0013b772f9beac7c01/google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:461665ff58895f508e2866824a47bdee72497b091c730071f2b7575d5762ab65"},
+    {url = "https://files.pythonhosted.org/packages/3f/a7/d9709429d1eae1c4907b3b9aab866de26acc5ca42c4237d216acf0b7033a/google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:02ebb8bf46c13e36998aeaad1de9b48f4caf545e91d14041270d9dca767b780c"},
+    {url = "https://files.pythonhosted.org/packages/41/3f/8141b03ad127fc569c3efda2bfe31d64665e02e2b8b7fbf7b25ea914c27a/google_crc32c-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1034d91442ead5a95b5aaef90dbfaca8633b0247d1e41621d1e9f9db88c36298"},
+    {url = "https://files.pythonhosted.org/packages/42/28/1eb1aba5afaf7c8f668c7d493eff003ae8613d47b71e15a60ab65e25c997/google_crc32c-1.5.0-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:f314013e7dcd5cf45ab1945d92e713eec788166262ae8deb2cfacd53def27325"},
+    {url = "https://files.pythonhosted.org/packages/45/b8/e8de2b6d45d9ca777469ebf6f66137fe393c61175e9717805f924ee81e88/google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd67cf24a553339d5062eff51013780a00d6f97a39ca062781d06b3a73b15462"},
+    {url = "https://files.pythonhosted.org/packages/4a/1f/2182df8cbd52dca8a54957ebb979f3844e244be1a9eeef69c36c9ea74e70/google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e560628513ed34759456a416bf86b54b2476c59144a9138165c9a1575801d0d9"},
+    {url = "https://files.pythonhosted.org/packages/4b/9d/25cfb36f8e6fb0dd47e0ce368762a3ce371ed84d888acd8865a182f8169a/google_crc32c-1.5.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:278d2ed7c16cfc075c91378c4f47924c0625f5fc84b2d50d921b18b7975bd210"},
+    {url = "https://files.pythonhosted.org/packages/56/4f/cfde2048fffdfe63ef35b3acb2e463c341e186d697e798883833bcd0cfdb/google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5ae44e10a8e3407dbe138984f21e536583f2bba1be9491239f942c2464ac0894"},
+    {url = "https://files.pythonhosted.org/packages/58/47/5374e1e82d2337a02506a339b1769a5af5f56abaa41bdc0a38885b7c014a/google_crc32c-1.5.0-pp39-pypy39_pp73-macosx_10_9_x86_64.whl", hash = "sha256:b1f8133c9a275df5613a451e73f36c2aea4fe13c5c8997e22cf355ebd7bd0728"},
+    {url = "https://files.pythonhosted.org/packages/58/50/f8f0a69f129473018e19de86d599781b863ce5017b325a554013a87f5522/google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:de06adc872bcd8c2a4e0dc51250e9e65ef2ca91be023b9d13ebd67c2ba552e1e"},
+    {url = "https://files.pythonhosted.org/packages/5a/4a/999197b83bb5d24928a3cba2e59d3830910df5bd5f3c7a5253e623d8f9c3/google_crc32c-1.5.0-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:398af5e3ba9cf768787eef45c803ff9614cc3e22a5b2f7d7ae116df8b11e3314"},
+    {url = "https://files.pythonhosted.org/packages/5a/6b/882314bb535e44bb5578d60859497c5b9d82103960f3b6ecdaf42d3fab34/google_crc32c-1.5.0-cp310-cp310-win32.whl", hash = "sha256:2e920d506ec85eb4ba50cd4228c2bec05642894d4c73c59b3a2fe20346bd00ee"},
+    {url = "https://files.pythonhosted.org/packages/5b/28/38353a232bdd1b3bca3732cd0a87dc2ee5bec2ce149cbacadfd47066c97e/google_crc32c-1.5.0-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:6f998db4e71b645350b9ac28a2167e6632c239963ca9da411523bb439c5c514d"},
+    {url = "https://files.pythonhosted.org/packages/69/0f/7f89ae2b22c55273110a44a7ed55a2948bc213fb58983093fbefcdfd2d13/google_crc32c-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:cae0274952c079886567f3f4f685bcaf5708f0a23a5f5216fdab71f81a6c0273"},
+    {url = "https://files.pythonhosted.org/packages/69/59/08ef90c8c0ad56e1903895dd419749dc9cd77617b4c05f513c205de8f1fd/google_crc32c-1.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f13cae8cc389a440def0c8c52057f37359014ccbc9dc1f0827936bcd367c6100"},
+    {url = "https://files.pythonhosted.org/packages/72/92/2a2fa23db7d0b0382accbdf09768c28f7c07fc8c354cdcf2f44a47f4314e/google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:77e2fd3057c9d78e225fa0a2160f96b64a824de17840351b26825b0848022906"},
+    {url = "https://files.pythonhosted.org/packages/77/1a/cb80480e05bc5f8710be7a7ca2e2ce266006ee5aef42190749beffc65a21/google_crc32c-1.5.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6ac08d24c1f16bd2bf5eca8eaf8304812f44af5cfe5062006ec676e7e1d50afc"},
+    {url = "https://files.pythonhosted.org/packages/7c/5e/964aee31aa04921a13fb923a07d30ffde5a2bc9151273203eb4407607e84/google_crc32c-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:edfedb64740750e1a3b16152620220f51d58ff1b4abceb339ca92e934775c27a"},
+    {url = "https://files.pythonhosted.org/packages/7e/ee/998646a47a747c099acd236f77100728fc9dc8e712e3c3d10583e14361e5/google_crc32c-1.5.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:1c7abdac90433b09bad6c43a43af253e688c9cfc1c86d332aed13f9a7c7f65e2"},
+    {url = "https://files.pythonhosted.org/packages/82/d8/ee36a80de9f381ce267adcc9b8c252d3f7f15fecff164389217a3e515774/google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7c074fece789b5034b9b1404a1f8208fc2d4c6ce9decdd16e8220c5a793e6f61"},
+    {url = "https://files.pythonhosted.org/packages/88/ea/e53fbafcd0be2349d9c2a6912646cdfc47cfc5c22be9a8a5156552e33821/google_crc32c-1.5.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:a1fd716e7a01f8e717490fbe2e431d2905ab8aa598b9b12f8d10abebb36b04dd"},
+    {url = "https://files.pythonhosted.org/packages/8b/08/7d4e899a866df7217a3bed6de436139ae789f651dda3b9f6e84d31f0989f/google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2ad40e31093a4af319dadf503b2467ccdc8f67c72e4bcba97f8c10cb078207b5"},
+    {url = "https://files.pythonhosted.org/packages/94/c9/b0563fe4b331f89b2da88906aaaa3aac125766bd8a7d2ea606b4c2ec337e/google_crc32c-1.5.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:83c681c526a3439b5cf94f7420471705bbf96262f49a6fe546a6db5f687a3d4a"},
+    {url = "https://files.pythonhosted.org/packages/97/8e/e8ebb46a7ec0b995746fc995a2f625c7b34777a40e4e5728db0055d0b072/google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fd8536e902db7e365f49e7d9029283403974ccf29b13fc7028b97e2295b33556"},
+    {url = "https://files.pythonhosted.org/packages/98/75/c208efbd782d8816eee355671e38c5e4684d7536b6633e47a5233e902533/google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b747a674c20a67343cb61d43fdd9207ce5da6a99f629c6e2541aa0e89215bcd"},
+    {url = "https://files.pythonhosted.org/packages/9f/f2/f7f130a11bac632287659c1df246400350c2554fb3c4a800d7d83b75b769/google_crc32c-1.5.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:635f5d4dd18758a1fbd1049a8e8d2fee4ffed124462d837d1a02a0e009c3ab31"},
+    {url = "https://files.pythonhosted.org/packages/a5/25/c5bb4769b1ef0d74af968c1e24a234066cf0558126dcfa92b0ffd7e21a9a/google_crc32c-1.5.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:98cb4d057f285bd80d8778ebc4fde6b4d509ac3f331758fb1528b733215443ae"},
+    {url = "https://files.pythonhosted.org/packages/a6/ba/9826da8b2e4778e963339aed1cff6dfd7efe938011d8eff804b32f5e3e12/google_crc32c-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:759ce4851a4bb15ecabae28f4d2e18983c244eddd767f560165563bf9aefbc8d"},
+    {url = "https://files.pythonhosted.org/packages/a9/d0/04f2846f0af1c683eb3b664c9de9543da1e66a791397456a65073b6054a2/google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:116a7c3c616dd14a3de8c64a965828b197e5f2d121fedd2f8c5585c547e87b02"},
+    {url = "https://files.pythonhosted.org/packages/ab/e1/6cd2fbffabc28ba0b611f3c84ae25cf146cf4683852d84737b6256ed2c10/google_crc32c-1.5.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:37933ec6e693e51a5b07505bd05de57eee12f3e8c32b07da7e73669398e6630a"},
+    {url = "https://files.pythonhosted.org/packages/ab/ef/48efc65af146635b66e883e3b7cf5a0eafe6e01cfbb1f94bd5e5b73ed2be/google_crc32c-1.5.0-cp38-cp38-win32.whl", hash = "sha256:fe70e325aa68fa4b5edf7d1a4b6f691eb04bbccac0ace68e34820d283b5f80d4"},
+    {url = "https://files.pythonhosted.org/packages/ad/42/f8d35568ae119d7485ab5d3838c0aff0739f175d38e319004203e39805b8/google_crc32c-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:74dea7751d98034887dbd821b7aae3e1d36eda111d6ca36c206c44478035709c"},
+    {url = "https://files.pythonhosted.org/packages/b0/70/1497215cf1d234be473af3b7b8ec0239bcff810b4e00a12fff31240390e4/google_crc32c-1.5.0-cp39-cp39-win32.whl", hash = "sha256:7f57f14606cd1dd0f0de396e1e53824c371e9544a822648cd76c034d209b559c"},
+    {url = "https://files.pythonhosted.org/packages/b3/86/0621b9b3a454e53cf4a7ec29bee8fb7bf6927d11bb544d66344fc9e460c3/google_crc32c-1.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:c02ec1c5856179f171e032a31d6f8bf84e5a75c45c33b2e20a3de353b266ebd8"},
+    {url = "https://files.pythonhosted.org/packages/b5/9a/a9bc2603a17d4fda1827d7ab0bb18d1eb5b9df80b9e11955ed9f727ace09/google_crc32c-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:596d1f98fc70232fcb6590c439f43b350cb762fb5d61ce7b0e9db4539654cc13"},
+    {url = "https://files.pythonhosted.org/packages/b7/09/768d2ca0c10a0765f83c6d06a5e40f3083cb75b8e7718ac22edff997aefc/google_crc32c-1.5.0-cp311-cp311-win32.whl", hash = "sha256:66741ef4ee08ea0b2cc3c86916ab66b6aef03768525627fd6a1b34968b4e3709"},
+    {url = "https://files.pythonhosted.org/packages/b7/53/0170614ccaf34ac602c877929998dbca4923f0c401f0bea6f0d5a38a3e57/google_crc32c-1.5.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e2096eddb4e7c7bdae4bd69ad364e55e07b8316653234a56552d9c988bd2d61b"},
+    {url = "https://files.pythonhosted.org/packages/b9/14/e9ba87ccc931323d79574924bf582633cc467e196bb63a49bc5a75c1dd58/google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:64e52e2b3970bd891309c113b54cf0e4384762c934d5ae56e283f9a0afcd953e"},
+    {url = "https://files.pythonhosted.org/packages/bb/47/3dd904821181dbd20a8a72732592bf6ad5fb8a9d6b81d118eaf209089c48/google_crc32c-1.5.0-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c99616c853bb585301df6de07ca2cadad344fd1ada6d62bb30aec05219c45d2"},
+    {url = "https://files.pythonhosted.org/packages/bc/53/488ed34d5e461d5e868a44e1326ef1408f8da5a998a38d896b299b48b7c4/google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:998679bf62b7fb599d2878aa3ed06b9ce688b8974893e7223c60db155f26bd8d"},
+    {url = "https://files.pythonhosted.org/packages/c5/2b/03ed959db876bff7d28aaca36cce8dc1b82e1c9a3e3fc05fea67dd382a8f/google_crc32c-1.5.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:024894d9d3cfbc5943f8f230e23950cd4906b2fe004c72e29b209420a1e6b05a"},
+    {url = "https://files.pythonhosted.org/packages/ce/8b/02bf4765c487901c8660290ade9929d65a6151c367ba32e75d136ef2d0eb/google_crc32c-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:ba1eb1843304b1e5537e1fca632fa894d6f6deca8d6389636ee5b4797affb968"},
+    {url = "https://files.pythonhosted.org/packages/d2/b1/e85646501adbc960f9e4695b058286d2fcfd890c9aad3ae73832fdb73911/google_crc32c-1.5.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:d5280312b9af0976231f9e317c20e4a61cd2f9629b7bfea6a693d1878a264ebd"},
+    {url = "https://files.pythonhosted.org/packages/d3/a5/4bb58448fffd36ede39684044df93a396c13d1ea3516f585767f9f960352/google-crc32c-1.5.0.tar.gz", hash = "sha256:89284716bc6a5a415d4eaa11b1726d2d60a0cd12aadf5439828353662ede9dd7"},
+    {url = "https://files.pythonhosted.org/packages/d7/24/b989665f0a17355461bc34b25a5e95376b3e1c0a044e8cb1f37f7b57b8a9/google_crc32c-1.5.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19e0a019d2c4dcc5e598cd4a4bc7b008546b0358bd322537c74ad47a5386884f"},
+    {url = "https://files.pythonhosted.org/packages/f0/24/6d6ad7630637fc79c0036635ec11f7707f7b14fed5b2d09b8878bf1c7e00/google_crc32c-1.5.0-cp37-cp37m-win_amd64.whl", hash = "sha256:67b741654b851abafb7bc625b6d1cdd520a379074e64b6a128e3b688c3c04740"},
+    {url = "https://files.pythonhosted.org/packages/f4/44/6af2ffd9584f424fddd0711cd86f498d42dc5ad3a1f26a339c8535bd6486/google_crc32c-1.5.0-pp37-pypy37_pp73-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8f24ed114432de109aa9fd317278518a5af2d31ac2ea6b952b2f7782b43da091"},
+    {url = "https://files.pythonhosted.org/packages/f8/b3/59b49d9c5f15172a35f5560b67048eae02a54927e60c370f3b91743b79f6/google_crc32c-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:be82c3c8cfb15b30f36768797a640e800513793d6ae1724aaaafe5bf86f8f346"},
+    {url = "https://files.pythonhosted.org/packages/f9/c2/eb43b40e799a9f85a43b358f2b4a2b4d60f8c22a7867aca5d6eb1b88b565/google_crc32c-1.5.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:5829b792bf5822fd0a6f6eb34c5f81dd074f01d570ed7f36aa101d6fc7a0a6e4"},
+    {url = "https://files.pythonhosted.org/packages/fc/76/3ef124b893aa280e45e95d2346160f1d1d5c0ffc89d3f6e446c83116fb91/google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c42c70cd1d362284289c6273adda4c6af8039a8ae12dc451dcd61cdabb8ab57"},
+    {url = "https://files.pythonhosted.org/packages/fc/7f/b8fc0644c6eea688532a58a0d872d28ea9ffc2fdf93956ce03aa07f19c6b/google_crc32c-1.5.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:1e986b206dae4476f41bcec1faa057851f3889503a70e1bdb2378d406223994a"},
+    {url = "https://files.pythonhosted.org/packages/fd/71/299a368347aeab3c89896cdfb67703161becbf5afbc1748a1850094828dc/google_crc32c-1.5.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8485b340a6a9e76c62a7dce3c98e5f102c9219f4cfbf896a00cf48caf078d438"},
+]
+"google-resumable-media 2.5.0" = [
+    {url = "https://files.pythonhosted.org/packages/a8/84/b8c526864e53ee265516453015f707432448546c525dcf2b89bfd6c67245/google_resumable_media-2.5.0-py2.py3-none-any.whl", hash = "sha256:da1bd943e2e114a56d85d6848497ebf9be6a14d3db23e9fc57581e7c3e8170ec"},
+    {url = "https://files.pythonhosted.org/packages/c0/1b/173eacfeb03e6d026c932cb810ace18987dc9ca219154c89d7746b348b9c/google-resumable-media-2.5.0.tar.gz", hash = "sha256:218931e8e2b2a73a58eb354a288e03a0fd5fb1c4583261ac6e4c078666468c93"},
+]
+"googleapis-common-protos 1.59.1" = [
+    {url = "https://files.pythonhosted.org/packages/28/9b/ea531afe585da044686ab13351c99dfbb2ca02b96c396874946d52d0e127/googleapis-common-protos-1.59.1.tar.gz", hash = "sha256:b35d530fe825fb4227857bc47ad84c33c809ac96f312e13182bdeaa2abe1178a"},
+    {url = "https://files.pythonhosted.org/packages/b3/b7/bbaa556e9ff0580f408c64ccf4db0c1414eec79e7151d33a10bc209ffb6d/googleapis_common_protos-1.59.1-py2.py3-none-any.whl", hash = "sha256:0cbedb6fb68f1c07e18eb4c48256320777707e7d0c55063ae56c15db3224a61e"},
+]
+"grpcio 1.56.0" = [
+    {url = "https://files.pythonhosted.org/packages/03/ab/49096965641b40b53c63cd4a65e4b2842ae154586015d6d020961de86d9d/grpcio-1.56.0-cp38-cp38-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f92a99ab0c7772fb6859bf2e4f44ad30088d18f7c67b83205297bfb229e0d2cf"},
+    {url = "https://files.pythonhosted.org/packages/0e/16/24c101edd3d2dc690830c4e0fe2652ed2fc9533a395f75f1e9f1c453860e/grpcio-1.56.0-cp39-cp39-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7beb84ebd0a3f732625124b73969d12b7350c5d9d64ddf81ae739bbc63d5b1ed"},
+    {url = "https://files.pythonhosted.org/packages/11/7f/947d3931463d97e767e761f05ae3598442dd22ab9756bf99291e5e37e698/grpcio-1.56.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa08affbf672d051cd3da62303901aeb7042a2c188c03b2c2a2d346fc5e81c14"},
+    {url = "https://files.pythonhosted.org/packages/14/37/b04a85ec5e201146a875ab2b3b0c3bddb50c7d8fbb89f32b64a733d4befd/grpcio-1.56.0-cp39-cp39-win32.whl", hash = "sha256:437af5a7673bca89c4bc0a993382200592d104dd7bf55eddcd141cef91f40bab"},
+    {url = "https://files.pythonhosted.org/packages/19/1e/866020537ca4fee532e31cdbfee272cd049fbd31c0e19f140505bc5424ea/grpcio-1.56.0-cp39-cp39-win_amd64.whl", hash = "sha256:4241a1c2c76e748023c834995cd916570e7180ee478969c2d79a60ce007bc837"},
+    {url = "https://files.pythonhosted.org/packages/20/2b/3cd3a0b91434882ab369d3bf37676166f1f06f5580236695f3f09a4aa209/grpcio-1.56.0-cp310-cp310-win32.whl", hash = "sha256:8b3b2c7b5feef90bc9a5fa1c7f97637e55ec3e76460c6d16c3013952ee479cd9"},
+    {url = "https://files.pythonhosted.org/packages/26/cb/a2debcb7fe7a6f90f27d589facb85aa69e8ce39660e8faff2775911f58ee/grpcio-1.56.0-cp310-cp310-manylinux_2_17_aarch64.whl", hash = "sha256:17f47aeb9be0da5337f9ff33ebb8795899021e6c0741ee68bd69774a7804ca86"},
+    {url = "https://files.pythonhosted.org/packages/28/f1/b65179056678e444893d6a3fdc434bde1ef583a79f1145f42c8ab18fd3fd/grpcio-1.56.0-cp310-cp310-linux_armv7l.whl", hash = "sha256:fb34ace11419f1ae321c36ccaa18d81cd3f20728cd191250be42949d6845bb2d"},
+    {url = "https://files.pythonhosted.org/packages/32/f7/ed1d9dcf12b867a7d4de8b2644932ea0b11d2355f2fa11222deba06576d3/grpcio-1.56.0-cp37-cp37m-win_amd64.whl", hash = "sha256:991224fd485e088d3cb5e34366053691a4848a6b7112b8f5625a411305c26691"},
+    {url = "https://files.pythonhosted.org/packages/3e/b2/381914940b6c456eb468c34e13467d24c6b45db812b4eb19cbb575df614b/grpcio-1.56.0-cp37-cp37m-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:66f0369d27f4c105cd21059d635860bb2ea81bd593061c45fb64875103f40e4a"},
+    {url = "https://files.pythonhosted.org/packages/46/49/a6ddc008059e6011c028ad7fea0dcefb4f391885fb9271f2f2b42d3c47af/grpcio-1.56.0-cp38-cp38-manylinux_2_17_aarch64.whl", hash = "sha256:72836b5a1d4f508ffbcfe35033d027859cc737972f9dddbe33fb75d687421e2e"},
+    {url = "https://files.pythonhosted.org/packages/4a/5f/3e0d819b52c9c3eac4c98f457ffdae9e63ebe93518e7686a5b48fd9068aa/grpcio-1.56.0-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:881575f240eb5db72ddca4dc5602898c29bc082e0d94599bf20588fb7d1ee6a0"},
+    {url = "https://files.pythonhosted.org/packages/4d/b8/eaa30c0831ee0cc2e7d63e56dab72b0f129602f8645a324e80ff08357bc9/grpcio-1.56.0-cp311-cp311-win32.whl", hash = "sha256:50f4daa698835accbbcc60e61e0bc29636c0156ddcafb3891c987e533a0031ba"},
+    {url = "https://files.pythonhosted.org/packages/54/83/d6957f030e9c95ae063741afa93992b974cde21646a00451b16b5473413d/grpcio-1.56.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38fdf5bd0a1c754ce6bf9311a3c2c7ebe56e88b8763593316b69e0e9a56af1de"},
+    {url = "https://files.pythonhosted.org/packages/56/51/bbdd996f2773c88a6a8bab1115028bf30d4405f09a4e4d413b9061353003/grpcio-1.56.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:14e70b4dda3183abea94c72d41d5930c333b21f8561c1904a372d80370592ef3"},
+    {url = "https://files.pythonhosted.org/packages/5c/b7/21ef78919c5c09a5998a22622bb242565c8e61ee97fd1a9118507afcf504/grpcio-1.56.0-cp37-cp37m-macosx_10_10_universal2.whl", hash = "sha256:c2148170e01d464d41011a878088444c13413264418b557f0bdcd1bf1b674a0e"},
+    {url = "https://files.pythonhosted.org/packages/61/a3/3d341f65ed3988c9530af277aa4c1fc513e0572d658ea2a81006f8f83787/grpcio-1.56.0-cp39-cp39-manylinux_2_17_aarch64.whl", hash = "sha256:76b6e6e1ee9bda32e6e933efd61c512e9a9f377d7c580977f090d1a9c78cca44"},
+    {url = "https://files.pythonhosted.org/packages/63/78/721e7474c7a0da305bb0ca2896f796a27bc17bfd5d36305fc25ab9e7c964/grpcio-1.56.0-cp38-cp38-win_amd64.whl", hash = "sha256:c63bc5ac6c7e646c296fed9139097ae0f0e63f36f0864d7ce431cce61fe0118a"},
+    {url = "https://files.pythonhosted.org/packages/64/ad/dd0727b6df44339ca178361a4b90bc2e2a016a03a57fffce9bdedbba84a4/grpcio-1.56.0-cp37-cp37m-linux_armv7l.whl", hash = "sha256:b1f4b6f25a87d80b28dd6d02e87d63fe1577fe6d04a60a17454e3f8077a38279"},
+    {url = "https://files.pythonhosted.org/packages/66/c9/59cd04aafcd55a0b4eda69eac100f44c4c7a9ed42a52623464f5b2e9d7a6/grpcio-1.56.0-cp310-cp310-win_amd64.whl", hash = "sha256:03a80451530fd3b8b155e0c4480434f6be669daf7ecba56f73ef98f94222ee01"},
+    {url = "https://files.pythonhosted.org/packages/6d/25/93e8b1ff58b376a3413df301cc79b0aa0c99c3bf1a03191aed7790214dcb/grpcio-1.56.0-cp311-cp311-win_amd64.whl", hash = "sha256:59c4e606993a47146fbeaf304b9e78c447f5b9ee5641cae013028c4cca784617"},
+    {url = "https://files.pythonhosted.org/packages/76/8d/cfe17b92ca749170629c85875703dcc146094a477031bdef6d41db50891f/grpcio-1.56.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8674fdbd28266d8efbcddacf4ec3643f76fe6376f73283fd63a8374c14b0ef7c"},
+    {url = "https://files.pythonhosted.org/packages/77/99/342e15db586debbd7f16ac81664e8efb339e55c9da1a0aba7e6939d00e65/grpcio-1.56.0-cp311-cp311-linux_armv7l.whl", hash = "sha256:64bd3abcf9fb4a9fa4ede8d0d34686314a7075f62a1502217b227991d9ca4245"},
+    {url = "https://files.pythonhosted.org/packages/7a/30/1545e97c65a63d2204d9ee2e5a005cd285cd8b7acef27dcfee361bb3b3cd/grpcio-1.56.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83ec714bbbe9b9502177c842417fde39f7a267031e01fa3cd83f1ca49688f537"},
+    {url = "https://files.pythonhosted.org/packages/7f/d2/653645f1e81352313ec17b42101f9f678824fd099e6693064e741536e6d7/grpcio-1.56.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5d2fc471668a7222e213f86ef76933b18cdda6a51ea1322034478df8c6519959"},
+    {url = "https://files.pythonhosted.org/packages/83/c2/e224e2f1c1b7738d123e7f6c452d0b2e1372f60c1be07e6d67c4c6c8b1ad/grpcio-1.56.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:defdd14b518e6e468466f799aaa69db0355bca8d3a5ea75fb912d28ba6f8af31"},
+    {url = "https://files.pythonhosted.org/packages/88/6b/14706f48398037f5c73b13ab1d127d0afa035198c469f5498608b8809638/grpcio-1.56.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:b4638a796778329cc8e142e4f57c705adb286b3ba64e00b0fa91eeb919611be8"},
+    {url = "https://files.pythonhosted.org/packages/88/9f/95f1ed9804844545a34b03fc7492b7c077cc7c3852b4653c7b7238fe677a/grpcio-1.56.0-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:79d4c5911d12a7aa671e5eb40cbb50a830396525014d2d6f254ea2ba180ce637"},
+    {url = "https://files.pythonhosted.org/packages/92/2a/89c961495127c0af765aa3cf7f0e2b36ff360802ce8a7281e1bd87da1572/grpcio-1.56.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:fdc3a895791af4addbb826808d4c9c35917c59bb5c430d729f44224e51c92d61"},
+    {url = "https://files.pythonhosted.org/packages/92/31/da80feb6f67d1fee2d0e6b6113b9ce79501476d2b87651b53e44411e1df0/grpcio-1.56.0-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:43c50d810cc26349b093bf2cfe86756ab3e9aba3e7e681d360930c1268e1399a"},
+    {url = "https://files.pythonhosted.org/packages/97/b3/fb1dcedf39be0854403a28935f2c1e7e4025b3579801c7e91a1cac5b665c/grpcio-1.56.0-cp39-cp39-macosx_10_10_universal2.whl", hash = "sha256:d596408bab632ec7b947761e83ce6b3e7632e26b76d64c239ba66b554b7ee286"},
+    {url = "https://files.pythonhosted.org/packages/a2/33/6ab84df6d558bbda4595de1db670e83b1fa11364c6267f60468d8e52087e/grpcio-1.56.0-cp38-cp38-linux_armv7l.whl", hash = "sha256:c6f36621aabecbaff3e70c4d1d924c76c8e6a7ffec60c331893640a4af0a8037"},
+    {url = "https://files.pythonhosted.org/packages/a3/d3/2f8452752ee8b0bf701eb46341caa0192dfdcd8fc982230c9ef1ca217976/grpcio-1.56.0-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:e2db108b4c8e29c145e95b0226973a66d73ae3e3e7fae00329294af4e27f1c42"},
+    {url = "https://files.pythonhosted.org/packages/a9/6e/fa9785a95e70d60b9b2b75944e422b06c62eaed183abdfcdc0b7812b1e21/grpcio-1.56.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187b8f71bad7d41eea15e0c9812aaa2b87adfb343895fffb704fb040ca731863"},
+    {url = "https://files.pythonhosted.org/packages/b4/ec/332ecc2883fcd0722f32feff057b989242b387e72ee7c20aad4b4c77bdd2/grpcio-1.56.0-cp38-cp38-win32.whl", hash = "sha256:bd55f743e654fb050c665968d7ec2c33f03578a4bbb163cfce38024775ff54cc"},
+    {url = "https://files.pythonhosted.org/packages/c9/7e/9b60f32e91c5a9545973498868fcdde6366e7c8223b6f51f87f6f0691de7/grpcio-1.56.0-cp311-cp311-manylinux_2_17_aarch64.whl", hash = "sha256:4f84a6fd4482e5fe73b297d4874b62a535bc75dc6aec8e9fe0dc88106cd40397"},
+    {url = "https://files.pythonhosted.org/packages/cc/9c/811d5347092fb0df43fd4d8ab8dfe3c429a39a5d74e1fd52090238beb557/grpcio-1.56.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b5ce42a5ebe3e04796246ba50357f1813c44a6efe17a37f8dc7a5c470377312"},
+    {url = "https://files.pythonhosted.org/packages/ce/77/b5b741446567a56fe95983d915c8173064e8ec8f158058da238733acbd50/grpcio-1.56.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c243b158dd7585021d16c50498c4b2ec0a64a6119967440c5ff2d8c89e72330e"},
+    {url = "https://files.pythonhosted.org/packages/cf/ff/e02442d57b1d36cf945dd6dadc92c5e4e98544b70a539b8f977da392ab5f/grpcio-1.56.0-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:8219f17baf069fe8e42bd8ca0b312b875595e43a70cabf397be4fda488e2f27d"},
+    {url = "https://files.pythonhosted.org/packages/d0/b7/96648e85ef4da6d4ca2d532a9a47efff1c9e2d7e7b1d6061eec046d05f09/grpcio-1.56.0-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:4feee75565d1b5ab09cb3a5da672b84ca7f6dd80ee07a50f5537207a9af543a4"},
+    {url = "https://files.pythonhosted.org/packages/d2/62/b2da52d8de3e7c785613cda521e405d2fe85da5728c7c84fd8ea0fce522e/grpcio-1.56.0-cp38-cp38-macosx_10_10_universal2.whl", hash = "sha256:1eadd6de258901929223f422ffed7f8b310c0323324caf59227f9899ea1b1674"},
+    {url = "https://files.pythonhosted.org/packages/ee/d6/62ea04e71abe92406baf8fbe25daee5e90d45571206b8e93c4812ea958b6/grpcio-1.56.0.tar.gz", hash = "sha256:4c08ee21b3d10315b8dc26f6c13917b20ed574cdbed2d2d80c53d5508fdcc0f2"},
+    {url = "https://files.pythonhosted.org/packages/f3/c8/8fca7cae01afe29680d976772413c7d2b200a4a5a17f9c9424d8fd3d8f28/grpcio-1.56.0-cp37-cp37m-manylinux_2_17_aarch64.whl", hash = "sha256:0409de787ebbf08c9d2bca2bcc7762c1efe72eada164af78b50567a8dfc7253c"},
+    {url = "https://files.pythonhosted.org/packages/f5/b1/3d8bf6c880b06d96695399ac9cf6b5e2b3af35139049d45050fdb0f0cffc/grpcio-1.56.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:008767c0aed4899e657b50f2e0beacbabccab51359eba547f860e7c55f2be6ba"},
+    {url = "https://files.pythonhosted.org/packages/f9/1d/3fc4220898f5b52b943490ab7c89bb81fb1cfc2116a2c6bc814d474897a8/grpcio-1.56.0-cp39-cp39-linux_armv7l.whl", hash = "sha256:c0bc9dda550785d23f4f025be614b7faa8d0293e10811f0f8536cf50435b7a30"},
+]
+"grpcio-status 1.56.0" = [
+    {url = "https://files.pythonhosted.org/packages/2b/21/aaff30111c5941fd9adb5abbf06e04a0e491a685f48ffb291f72ad595ec7/grpcio_status-1.56.0-py3-none-any.whl", hash = "sha256:e5f101c96686e9d4e94a114567960fdb00052aa3c818b029745e3db37dc9c613"},
+    {url = "https://files.pythonhosted.org/packages/e3/48/f5e1c0c55ebc847400d967db909ed9274a8eaf0c49036b96bb3ad07f2dc3/grpcio-status-1.56.0.tar.gz", hash = "sha256:9eca0b2dcda0782d3702df225918efd6d820f75f93cd5c51c7fb6a4ffbfea12c"},
+]
 "idna 3.4" = [
     {url = "https://files.pythonhosted.org/packages/8b/e1/43beb3d38dba6cb420cefa297822eac205a277ab43e5ba5d5c46faf96438/idna-3.4.tar.gz", hash = "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4"},
     {url = "https://files.pythonhosted.org/packages/fc/34/3030de6f1370931b9dbb4dad48f6ab1015ab1d32447850b9fc94e60097be/idna-3.4-py3-none-any.whl", hash = "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"},
@@ -848,9 +1159,28 @@ content_hash = "sha256:bdc1d6b34e3249a2b58cb691cd6a2dd99eb2808a61f2448368b625ad7
     {url = "https://files.pythonhosted.org/packages/9e/01/f38e2ff29715251cf25532b9082a1589ab7e4f571ced434f98d0139336dc/pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {url = "https://files.pythonhosted.org/packages/a1/16/db2d7de3474b6e37cbb9c008965ee63835bba517e22cdb8c35b5116b5ce1/pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
+"proto-plus 1.22.3" = [
+    {url = "https://files.pythonhosted.org/packages/36/5b/e02636d221917d6fa2a61289b3f16002eb4c93d51c0191ac8e896d527182/proto_plus-1.22.3-py3-none-any.whl", hash = "sha256:a49cd903bc0b6ab41f76bf65510439d56ca76f868adf0274e738bfdd096894df"},
+    {url = "https://files.pythonhosted.org/packages/41/bd/4022c9a6de35821f215fdefc8b4e68bf9a054d04f43246f0c89ba8a7538e/proto-plus-1.22.3.tar.gz", hash = "sha256:fdcd09713cbd42480740d2fe29c990f7fbd885a67efc328aa8be6ee3e9f76a6b"},
+]
 "proto-schema-parser 0.3.0" = [
     {url = "https://files.pythonhosted.org/packages/59/e7/aa4d9e47f39231c8ffe24e534135e3a3fdf91d1f0bc008bdfd321f3a8df5/proto_schema_parser-0.3.0-py3-none-any.whl", hash = "sha256:3531d01e25be7ac8c08a11da85d41999a497b3a3414e4753cb0118bd68a66f3a"},
     {url = "https://files.pythonhosted.org/packages/ef/d3/48bf167c1fcc47cf8b1154ab22a85b6e3874b95970cbc2e795b5ba1abbf4/proto_schema_parser-0.3.0.tar.gz", hash = "sha256:d255415fa1571419d644cd61dd43b56d88ac28ac188c4f44db2180197099eade"},
+]
+"protobuf 4.23.4" = [
+    {url = "https://files.pythonhosted.org/packages/01/cb/445b3e465abdb8042a41957dc8f60c54620dc7540dbcf9b458a921531ca2/protobuf-4.23.4-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:effeac51ab79332d44fba74660d40ae79985901ac21bca408f8dc335a81aa597"},
+    {url = "https://files.pythonhosted.org/packages/0e/76/aec5e6e2703eff3515cd13ff781fd32077809d3ebc166f7806578dbf2364/protobuf-4.23.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9053df6df8e5a76c84339ee4a9f5a2661ceee4a0dab019e8663c50ba324208b0"},
+    {url = "https://files.pythonhosted.org/packages/12/52/ee20d445b704503a5f4249cde385cc21eb3c7673870eb8ddfc07a15bb749/protobuf-4.23.4-cp39-cp39-win32.whl", hash = "sha256:6dd9b9940e3f17077e820b75851126615ee38643c2c5332aa7a359988820c720"},
+    {url = "https://files.pythonhosted.org/packages/41/ef/dc1a84cd6d78c0ff181ae76db14ed1fcfd0043f9a569c28eb1e6ec0da625/protobuf-4.23.4-cp38-cp38-win_amd64.whl", hash = "sha256:351cc90f7d10839c480aeb9b870a211e322bf05f6ab3f55fcb2f51331f80a7d2"},
+    {url = "https://files.pythonhosted.org/packages/5c/19/34458bf317755b7cb0a1391217c45465f70fd63890f26065c96c1ad975c3/protobuf-4.23.4-cp37-cp37m-win32.whl", hash = "sha256:c3e0939433c40796ca4cfc0fac08af50b00eb66a40bbbc5dee711998fb0bbc1e"},
+    {url = "https://files.pythonhosted.org/packages/6f/a7/872807299eb114956c665fb1717ce106a8874db08a724651ac4f78c1198c/protobuf-4.23.4-cp310-abi3-win32.whl", hash = "sha256:5fea3c64d41ea5ecf5697b83e41d09b9589e6f20b677ab3c48e5f242d9b7897b"},
+    {url = "https://files.pythonhosted.org/packages/71/42/3a7fc57f360f728f38eca6656e8d00edaf22bc0ffc35dd2936f23e5fbb3e/protobuf-4.23.4-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:fee88269a090ada09ca63551bf2f573eb2424035bcf2cb1b121895b01a46594a"},
+    {url = "https://files.pythonhosted.org/packages/80/70/dc63d340d27b8ff22022d7dd14b8d6d68b479a003eacdc4507150a286d9a/protobuf-4.23.4-cp310-abi3-win_amd64.whl", hash = "sha256:7b19b6266d92ca6a2a87effa88ecc4af73ebc5cfde194dc737cf8ef23a9a3b12"},
+    {url = "https://files.pythonhosted.org/packages/99/7b/1085be78abfb2b5f6467ccb316d6bbde59633e8f889c5ba605ebfd0a6ef8/protobuf-4.23.4-cp39-cp39-win_amd64.whl", hash = "sha256:0a5759f5696895de8cc913f084e27fd4125e8fb0914bb729a17816a33819f474"},
+    {url = "https://files.pythonhosted.org/packages/b0/07/fb712cce15ba456f7c24b82b97c8a7db2233f07037ffe61c9011660c592a/protobuf-4.23.4-py3-none-any.whl", hash = "sha256:e9d0be5bf34b275b9f87ba7407796556abeeba635455d036c7351f7c183ef8ff"},
+    {url = "https://files.pythonhosted.org/packages/b9/a5/634f9f3cd952750b50fa75a262b5c91ef55246ce161a3ddb9b85f29fc1a1/protobuf-4.23.4-cp38-cp38-win32.whl", hash = "sha256:e1c915778d8ced71e26fcf43c0866d7499891bca14c4368448a82edc61fdbc70"},
+    {url = "https://files.pythonhosted.org/packages/cb/d3/a164038605494d49acc4f9cda1c0bc200b96382c53edd561387263bb181d/protobuf-4.23.4-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:8547bf44fe8cec3c69e3042f5c4fb3e36eb2a7a013bb0a44c018fc1e427aafbd"},
+    {url = "https://files.pythonhosted.org/packages/d3/1c/de86d82a5fc780feca36ef52c1231823bb3140266af8a04ed6286957aa6e/protobuf-4.23.4.tar.gz", hash = "sha256:ccd9430c0719dce806b93f89c91de7977304729e55377f872a92465d548329a9"},
 ]
 "psycopg2-binary 2.9.6" = [
     {url = "https://files.pythonhosted.org/packages/01/76/512f0a878dd900902ed818156baccaf94c05d0450534f7b4f714932e3d7e/psycopg2_binary-2.9.6-cp311-cp311-win32.whl", hash = "sha256:1876843d8e31c89c399e31b97d4b9725a3575bb9c2af92038464231ec40f9edb"},
@@ -943,6 +1273,14 @@ content_hash = "sha256:bdc1d6b34e3249a2b58cb691cd6a2dd99eb2808a61f2448368b625ad7
     {url = "https://files.pythonhosted.org/packages/f8/fe/4e2d2cd7e0d544018d7c7fee3dcee80303e16111605716592dd5333a2212/pyarrow-10.0.1-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:e3fe5049d2e9ca661d8e43fab6ad5a4c571af12d20a57dffc392a014caebef65"},
     {url = "https://files.pythonhosted.org/packages/fd/3e/9f538cc3e048ae2de171ae4bb326c5482ba2bd63978c56bd29110e65ba09/pyarrow-10.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb627673cb98708ef00864e2e243f51ba7b4c1b9f07a1d821f98043eccd3f585"},
 ]
+"pyasn1 0.5.0" = [
+    {url = "https://files.pythonhosted.org/packages/14/e5/b56a725cbde139aa960c26a1a3ca4d4af437282e20b5314ee6a3501e7dfc/pyasn1-0.5.0-py2.py3-none-any.whl", hash = "sha256:87a2121042a1ac9358cabcaf1d07680ff97ee6404333bacca15f76aa8ad01a57"},
+    {url = "https://files.pythonhosted.org/packages/61/ef/945a8bcda7895717c8ba4688c08a11ef6454f32b8e5cb6e352a9004ee89d/pyasn1-0.5.0.tar.gz", hash = "sha256:97b7290ca68e62a832558ec3976f15cbf911bf5d7c7039d8b861c2a0ece69fde"},
+]
+"pyasn1-modules 0.3.0" = [
+    {url = "https://files.pythonhosted.org/packages/3b/e4/7dec823b1b5603c5b3c51e942d5d9e65efd6ff946e713a325ed4146d070f/pyasn1_modules-0.3.0.tar.gz", hash = "sha256:5bd01446b736eb9d31512a30d46c1ac3395d676c6f3cafa4c03eb54b9925631c"},
+    {url = "https://files.pythonhosted.org/packages/cd/8e/bea464350e1b8c6ed0da3a312659cb648804a08af6cacc6435867f74f8bd/pyasn1_modules-0.3.0-py2.py3-none-any.whl", hash = "sha256:d3ccd6ed470d9ffbc716be08bd90efbd44d0734bc9303818f7336070984a162d"},
+]
 "pycparser 2.21" = [
     {url = "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
     {url = "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -1005,6 +1343,10 @@ content_hash = "sha256:bdc1d6b34e3249a2b58cb691cd6a2dd99eb2808a61f2448368b625ad7
     {url = "https://files.pythonhosted.org/packages/58/2a/07c65fdc40846ecb8a9dcda2c38fcb5a06a3e39d08d4a4960916431951cb/pytest-7.3.2.tar.gz", hash = "sha256:ee990a3cc55ba808b80795a79944756f315c67c12b56abd3ac993a7b8c17030b"},
     {url = "https://files.pythonhosted.org/packages/7a/d0/de969198293cdea22b3a6fb99a99aeeddb7b3827f0823b33c5dc0734bbe5/pytest-7.3.2-py3-none-any.whl", hash = "sha256:cdcbd012c9312258922f8cd3f1b62a6580fdced17db6014896053d47cddf9295"},
 ]
+"python-dateutil 2.8.2" = [
+    {url = "https://files.pythonhosted.org/packages/36/7a/87837f39d0296e723bb9b62bbb257d0355c7f6128853c78955f57342a56d/python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+    {url = "https://files.pythonhosted.org/packages/4c/c4/13b4776ea2d76c115c1d1b84579f3764ee6d57204f6be27119f13a61d0a9/python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+]
 "pytz 2023.3" = [
     {url = "https://files.pythonhosted.org/packages/5e/32/12032aa8c673ee16707a9b6cdda2b09c0089131f35af55d443b6a9c69c1d/pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
     {url = "https://files.pythonhosted.org/packages/7f/99/ad6bd37e748257dd70d6f85d916cafe79c0b0f5e2e95b11f7fbc82bf3110/pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
@@ -1012,6 +1354,10 @@ content_hash = "sha256:bdc1d6b34e3249a2b58cb691cd6a2dd99eb2808a61f2448368b625ad7
 "requests 2.31.0" = [
     {url = "https://files.pythonhosted.org/packages/70/8e/0e2d847013cb52cd35b38c009bb167a1a26b2ce6cd6965bf26b47bc0bf44/requests-2.31.0-py3-none-any.whl", hash = "sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f"},
     {url = "https://files.pythonhosted.org/packages/9d/be/10918a2eac4ae9f02f6cfe6414b7a155ccd8f7f9d4380d62fd5b955065c3/requests-2.31.0.tar.gz", hash = "sha256:942c5a758f98d790eaed1a29cb6eefc7ffb0d1cf7af05c3d2791656dbd6ad1e1"},
+]
+"rsa 4.9" = [
+    {url = "https://files.pythonhosted.org/packages/49/97/fa78e3d2f65c02c8e1268b9aba606569fe97f6c8f7c2d74394553347c145/rsa-4.9-py3-none-any.whl", hash = "sha256:90260d9058e514786967344d0ef75fa8727eed8a7d2e43ce9f4bcf1b536174f7"},
+    {url = "https://files.pythonhosted.org/packages/aa/65/7d973b89c4d2351d7fb232c2e452547ddfa243e93131e7cfa766da627b52/rsa-4.9.tar.gz", hash = "sha256:e38464a49c6c85d7f1351b0126661487a7e0a14a50f1675ec50eb34d4f20ef21"},
 ]
 "setuptools 67.8.0" = [
     {url = "https://files.pythonhosted.org/packages/03/20/630783571e76e5fa5f3e9f29398ca3ace377207b8196b54e0ffdf09f12c1/setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ proto = [
 hive = [
     "pymetastore>=0.2.0",
 ]
+bigquery = [
+    "google-cloud-bigquery>=3.11.3",
+]
 
 [build-system]
 requires = ["pdm-pep517>=1.0.0"]

--- a/recap/readers/bigquery.py
+++ b/recap/readers/bigquery.py
@@ -1,0 +1,93 @@
+from google.cloud import bigquery
+
+from recap.types import (
+    BoolType,
+    BytesType,
+    FloatType,
+    IntType,
+    ListType,
+    StringType,
+    StructType,
+)
+
+
+class BigQueryReader:
+    def __init__(self, client: bigquery.Client):
+        self.client = client
+
+    def to_recap(self, dataset: str, table: str):
+        table_ref = self.client.dataset(dataset).table(table)
+        table_obj = self.client.get_table(table_ref)
+        return self._parse_fields(table_obj.schema)
+
+    def _parse_fields(self, fields: list[bigquery.SchemaField]) -> StructType:
+        recap_fields = []
+        for field in fields:
+            match field.field_type:
+                case "STRING" | "JSON":
+                    # I'm having a hard time finding the max string length in BQ. This link:
+                    # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types
+                    # Says "2 logical bytes + the UTF-8 encoded string size", so I'm assuming
+                    # the 2 logical bytes are a uint16 length header, which is 65_536.
+                    field_type = StringType(bytes_=field.max_length or 65_536)
+                case "BYTES":
+                    field_type = BytesType(bytes_=field.max_length or 65_536)
+                case "INT64" | "INTEGER" | "INT" | "SMALLINT" | "TINYINT" | "BYTEINT":
+                    field_type = IntType(bits=64)
+                case "FLOAT" | "FLOAT64":
+                    field_type = FloatType(bits=64)
+                case "BOOLEAN":
+                    field_type = BoolType()
+                case "TIMESTAMP" | "DATETIME":
+                    field_type = IntType(
+                        logical="build.recap.Timestamp",
+                        bits=64,
+                        unit="microsecond",
+                    )
+                case "TIME":
+                    field_type = IntType(
+                        logical="build.recap.Time",
+                        bits=32,
+                        unit="microsecond",
+                    )
+                case "DATE":
+                    field_type = IntType(
+                        logical="build.recap.Date",
+                        bits=32,
+                        unit="day",
+                    )
+                case "RECORD" | "STRUCT":
+                    field_type = self._parse_fields(list(field.fields))
+                case "NUMERIC" | "DECIMAL":
+                    field_type = BytesType(
+                        logical="build.recap.Decimal",
+                        bytes_=16,
+                        variable=False,
+                        precision=field.precision or 38,
+                        scale=field.scale or 0,
+                    )
+                case "BIGNUMERIC" | "BIGDECIMAL":
+                    field_type = BytesType(
+                        logical="build.recap.Decimal",
+                        bytes_=32,
+                        variable=False,
+                        precision=field.precision or 76,
+                        scale=field.scale or 0,
+                    )
+                case _:
+                    raise ValueError(f"Unrecognized field type: {field.field_type}")
+
+            if field.mode == "REPEATED":
+                field_type = ListType(field_type)
+            if field.mode == "NULLABLE":
+                field_type = field_type.make_nullable()
+            if name := field.name:
+                field_type.extra_attrs["name"] = name
+            if description := field.description:
+                field_type.doc = description
+            if default := field.default_value_expression:
+                field_type.extra_attrs["default"] = default
+
+            recap_fields.append(field_type)
+
+        return StructType(recap_fields)

--- a/tests/integration/readers/test_bigquery.py
+++ b/tests/integration/readers/test_bigquery.py
@@ -1,0 +1,427 @@
+import pytest
+from google.api_core.client_options import ClientOptions
+from google.auth.credentials import AnonymousCredentials
+from google.cloud import bigquery
+from google.cloud.bigquery import QueryJobConfig
+
+from recap.readers.bigquery import BigQueryReader
+from recap.types import (
+    BoolType,
+    BytesType,
+    FloatType,
+    IntType,
+    ListType,
+    NullType,
+    StringType,
+    StructType,
+    UnionType,
+)
+
+
+@pytest.fixture(scope="module")
+def client():
+    client_options = ClientOptions(api_endpoint="http://localhost:9050")
+    client = bigquery.Client(
+        "test_project",
+        client_options=client_options,
+        credentials=AnonymousCredentials(),
+    )
+    return client
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_data(client):
+    # Creating a table with all primitive types.
+    client.query(
+        query="""
+        CREATE TABLE `test_dataset.test_table` (
+            test_string STRING,
+            test_bytes BYTES,
+            test_int64 INT64,
+            test_float64 FLOAT64,
+            test_boolean BOOLEAN,
+            test_timestamp TIMESTAMP,
+            test_datetime DATETIME,
+            test_date DATE,
+            test_time TIME,
+            test_numeric NUMERIC,
+            test_bigdecimal BIGNUMERIC
+        )
+        """,
+        job_config=QueryJobConfig(),
+    )
+
+    # Creating a table with REQUIRED primitive types.
+    client.query(
+        query="""
+        CREATE TABLE `test_dataset.test_table_required` (
+            test_string STRING NOT NULL,
+            test_bytes BYTES NOT NULL,
+            test_int64 INT64 NOT NULL,
+            test_float64 FLOAT64 NOT NULL,
+            test_boolean BOOLEAN NOT NULL,
+            test_timestamp TIMESTAMP NOT NULL,
+            test_datetime DATETIME NOT NULL,
+            test_date DATE NOT NULL,
+            test_time TIME NOT NULL,
+            test_numeric NUMERIC NOT NULL,
+            test_bigdecimal BIGNUMERIC NOT NULL
+        )
+        """,
+        job_config=QueryJobConfig(),
+    )
+
+    # Creating a table with a nested STRUCT / RECORD type.
+    client.query(
+        query="""
+        CREATE TABLE `test_dataset.test_table_struct` (
+            test_record STRUCT<
+                test_boolean BOOLEAN,
+                nested_record STRUCT<
+                    test_nested_boolean BOOLEAN
+                >
+            >
+        )
+        """,
+        job_config=QueryJobConfig(),
+    )
+
+    # Creating a table with a repeated (array) type.
+    client.query(
+        query="""
+        CREATE TABLE `test_dataset.test_table_repeated` (
+            test_array ARRAY<STRING>
+        )
+        """,
+        job_config=QueryJobConfig(),
+    )
+
+    # Creating a table with a repeated RECORD type.
+    client.query(
+        query="""
+        CREATE TABLE `test_dataset.test_table_repeated_records` (
+            test_array ARRAY<STRUCT<test_boolean BOOLEAN, test_int64 INT64>>
+        )
+        """,
+        job_config=QueryJobConfig(),
+    )
+
+    # Creating a table with a default value.
+    client.query(
+        query="""
+        CREATE TABLE `test_dataset.test_table_default` (
+            test_string STRING DEFAULT "default_value"
+        )
+        """,
+        job_config=QueryJobConfig(),
+    )
+
+    # Creating a table with a column description.
+    client.query(
+        query="""
+        CREATE TABLE `test_dataset.test_table_description` (
+            test_string STRING OPTIONS(description="This is a test string column")
+        )
+        """,
+        job_config=QueryJobConfig(),
+    )
+
+
+def test_primitive_types(client):
+    reader = BigQueryReader(client)
+    recap_schema = reader.to_recap("test_dataset", "test_table")
+    recap_fields = recap_schema.fields
+
+    assert recap_fields[0] == UnionType(
+        types=[NullType(), StringType()],
+        default=None,
+        name="test_string",
+    )
+
+    assert recap_fields[1] == UnionType(
+        types=[NullType(), BytesType()],
+        default=None,
+        name="test_bytes",
+    )
+
+    assert recap_fields[2] == UnionType(
+        types=[NullType(), IntType(bits=64)],
+        default=None,
+        name="test_int64",
+    )
+
+    assert recap_fields[3] == UnionType(
+        types=[NullType(), FloatType(bits=64)],
+        default=None,
+        name="test_float64",
+    )
+
+    assert recap_fields[4] == UnionType(
+        types=[NullType(), BoolType()],
+        default=None,
+        name="test_boolean",
+    )
+
+    assert recap_fields[5] == UnionType(
+        types=[
+            NullType(),
+            IntType(
+                bits=64,
+                logical="build.recap.Timestamp",
+                unit="microsecond",
+            ),
+        ],
+        default=None,
+        name="test_timestamp",
+    )
+
+    assert recap_fields[6] == UnionType(
+        types=[
+            NullType(),
+            IntType(
+                bits=64,
+                logical="build.recap.Timestamp",
+                unit="microsecond",
+            ),
+        ],
+        default=None,
+        name="test_datetime",
+    )
+
+    assert recap_fields[7] == UnionType(
+        types=[
+            NullType(),
+            IntType(
+                bits=32,
+                logical="build.recap.Date",
+                unit="day",
+            ),
+        ],
+        default=None,
+        name="test_date",
+    )
+
+    assert recap_fields[8] == UnionType(
+        types=[
+            NullType(),
+            IntType(
+                bits=32,
+                logical="build.recap.Time",
+                unit="microsecond",
+            ),
+        ],
+        default=None,
+        name="test_time",
+    )
+
+    assert recap_fields[9] == UnionType(
+        types=[
+            NullType(),
+            BytesType(
+                bytes_=16,
+                variable=False,
+                logical="build.recap.Decimal",
+                precision=38,
+                scale=0,
+            ),
+        ],
+        default=None,
+        name="test_numeric",
+    )
+
+    assert recap_fields[10] == UnionType(
+        types=[
+            NullType(),
+            BytesType(
+                bytes_=32,
+                variable=False,
+                logical="build.recap.Decimal",
+                precision=76,
+                scale=0,
+            ),
+        ],
+        default=None,
+        name="test_bigdecimal",
+    )
+
+
+# TODO Remove xfail after https://github.com/goccy/bigquery-emulator/issues/210
+@pytest.mark.xfail(reason="BigQuery emulator does not support REQUIRED fields")
+def test_required_types(client):
+    reader = BigQueryReader(client)
+    recap_schema = reader.to_recap("test_dataset", "test_table_required")
+    recap_fields = recap_schema.fields
+
+    assert recap_fields[0] == StringType(name="test_string")
+
+    assert recap_fields[1] == BytesType(name="test_bytes")
+
+    assert recap_fields[2] == IntType(bits=64, name="test_int64")
+
+    assert recap_fields[3] == FloatType(bits=64, name="test_float64")
+
+    assert recap_fields[4] == BoolType(name="test_boolean")
+
+    assert recap_fields[5] == IntType(
+        bits=64,
+        logical="build.recap.Timestamp",
+        unit="microsecond",
+        name="test_timestamp",
+    )
+
+    assert recap_fields[6] == IntType(
+        bits=64,
+        logical="build.recap.Timestamp",
+        unit="microsecond",
+        name="test_datetime",
+    )
+
+    assert recap_fields[7] == IntType(
+        bits=32,
+        logical="build.recap.Date",
+        unit="day",
+        name="test_date",
+    )
+
+    assert recap_fields[8] == IntType(
+        bits=32,
+        logical="build.recap.Time",
+        unit="microsecond",
+        name="test_time",
+    )
+
+    assert recap_fields[9] == BytesType(
+        bytes_=16,
+        variable=False,
+        logical="build.recap.Decimal",
+        precision=38,
+        scale=0,
+        name="test_numeric",
+    )
+
+    assert recap_fields[10] == BytesType(
+        bytes_=32,
+        variable=False,
+        logical="build.recap.Decimal",
+        precision=76,
+        scale=0,
+        name="test_bigdecimal",
+    )
+
+
+def test_nested_struct_record_types(client):
+    reader = BigQueryReader(client)
+    recap_schema = reader.to_recap("test_dataset", "test_table_struct")
+    recap_fields = recap_schema.fields
+
+    assert recap_fields[0] == UnionType(
+        types=[
+            NullType(),
+            StructType(
+                fields=[
+                    UnionType(
+                        types=[
+                            NullType(),
+                            BoolType(),
+                        ],
+                        default=None,
+                        name="test_boolean",
+                    ),
+                    UnionType(
+                        types=[
+                            NullType(),
+                            StructType(
+                                fields=[
+                                    UnionType(
+                                        types=[
+                                            NullType(),
+                                            BoolType(),
+                                        ],
+                                        default=None,
+                                        name="test_nested_boolean",
+                                    ),
+                                ],
+                            ),
+                        ],
+                        default=None,
+                        name="nested_record",
+                    ),
+                ],
+            ),
+        ],
+        default=None,
+        name="test_record",
+    )
+
+
+def test_repeated_types(client):
+    reader = BigQueryReader(client)
+    recap_schema = reader.to_recap("test_dataset", "test_table_repeated")
+    recap_fields = recap_schema.fields
+
+    # ARRAYs can't be nullable and their elements can't be nullable. See:
+    # https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#array_nulls
+
+    assert recap_fields[0] == ListType(
+        values=StringType(),
+        name="test_array",
+    )
+
+
+def test_repeated_records(client):
+    reader = BigQueryReader(client)
+    recap_schema = reader.to_recap("test_dataset", "test_table_repeated_records")
+    recap_fields = recap_schema.fields
+
+    assert recap_fields[0] == ListType(
+        values=StructType(
+            fields=[
+                UnionType(
+                    types=[
+                        NullType(),
+                        BoolType(),
+                    ],
+                    default=None,
+                    name="test_boolean",
+                ),
+                UnionType(
+                    types=[
+                        NullType(),
+                        IntType(bits=64),
+                    ],
+                    default=None,
+                    name="test_int64",
+                ),
+            ],
+        ),
+        name="test_array",
+    )
+
+
+# TODO Remove xfail after https://github.com/goccy/bigquery-emulator/issues/211
+@pytest.mark.xfail(reason="BigQuery emulator does not support DEFAULT values")
+def test_default_value(client):
+    reader = BigQueryReader(client)
+    recap_schema = reader.to_recap("test_dataset", "test_table_default")
+    recap_fields = recap_schema.fields
+
+    assert recap_fields[0] == UnionType(
+        types=[NullType(), StringType()],
+        default="default_value",
+        name="test_string",
+    )
+
+
+# TODO Remove xfail after https://github.com/goccy/bigquery-emulator/issues/212
+@pytest.mark.xfail(reason="BigQuery emulator does not support OPTIONS")
+def test_column_description(client):
+    reader = BigQueryReader(client)
+    recap_schema = reader.to_recap("test_dataset", "test_table_description")
+    recap_fields = recap_schema.fields
+
+    assert recap_fields[0] == UnionType(
+        types=[NullType(), StringType()],
+        default=None,
+        name="test_string",
+        docs="This is a test string column",
+    )


### PR DESCRIPTION
Recap can now convert BigQuery table schemas to Recap StructTypes.

Some notes:

1. Nested types are supported (RECORD, STRUCT)
2. Repeated/ARRAYs are supported
3. JSON types are treated as STRING
4. STRING and BYTES have a max length of 65KiB by default

For (4), I had a really hard time nailing down the exact max string size in BQ. [This](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types) page says they have a 2 byte header on strings/bytes, which I assume is to store the byte length. Thus I went with 65KiB.

I'm also using [bigquery-emulator](https://github.com/goccy/bigquery-emulator) to test. I've only included integration tests.

Closes #285