### PR TITLE
Replace `venv` with PDM's virtualenv management

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,34 +25,28 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python3.10 -m venv venv
-        source venv/bin/activate
-        pip install pdm
+        pip3 install pdm
+        pdm self update
         pdm install
 
     - name: Run black
       run: |
-        source venv/bin/activate
         pdm run black --check --diff recap/ tests/
 
     - name: Run isort
       run: |
-        source venv/bin/activate
         pdm run isort recap/ tests/ --check-only --diff
 
     - name: Run pylint
       run: |
-        source venv/bin/activate
         pdm run pylint --fail-under=7.0 recap/ tests/
 
     - name: Run pyright
       run: |
-        source venv/bin/activate
         pdm run pyright
 
     - name: Test with pytest
       run: |
-        source venv/bin/activate
         pdm run pytest tests/unit -vv
 
   integration-tests:
@@ -143,12 +137,10 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python3.10 -m venv venv
-        source venv/bin/activate
-        pip install pdm
+        pip3 install pdm
+        pdm self update
         pdm install
 
     - name: Test with pytest
       run: |
-        source venv/bin/activate
         pdm run pytest tests/integration -vv


### PR DESCRIPTION
Main started failing with some certi issues. Everything continued to work fine for me with PDM locally, so I decided to ditch `python3 -m ven venv` in the CI in favor of PDM's virtualenv management. This fixed the cert issues.