### PR TITLE
Handle oddly sized floats in AvroConverter.from_recap

### DIFF
--- a/recap/converters/avro.py
+++ b/recap/converters/avro.py
@@ -86,8 +86,10 @@ class AvroConverter:
                     "logicalType": "decimal",
                     "precision": precision,
                 }
-            case FloatType(bits=int(bits)):
-                avro_schema["type"] = "double" if bits == 64 else "float"
+            case FloatType(bits=int(bits)) if bits <= 32:
+                avro_schema["type"] = "float"
+            case FloatType(bits=int(bits)) if bits <= 64:
+                avro_schema["type"] = "double"
             case StringType(bytes_=int(bytes_)) if bytes_ <= 9_223_372_036_854_775_807:
                 avro_schema["type"] = "string"
             case BytesType(

--- a/tests/unit/readers/test_snowflake.py
+++ b/tests/unit/readers/test_snowflake.py
@@ -1,5 +1,3 @@
-import os
-
 import fakesnow
 import snowflake.connector
 


### PR DESCRIPTION
AvroConverter's from_recap method was not converting Recap floats to Avro doubles unless they were exactly 64 bits. All other Recap floats were treated as Avro floats even if their bits were > 64.