### PR TITLE
Handle null value without quotes

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -560,6 +560,9 @@ def clean_dict(type_dict: dict | list | str) -> dict | list | str:
 
     type_name = type_dict.get("type")
 
+    if type_name is None:
+        type_name = "null"
+
     if isinstance(type_name, str):
         recap_type_class = TYPE_CLASSES.get(type_name, ProxyType)
         param_defaults = {}

--- a/recap/types.py
+++ b/recap/types.py
@@ -561,7 +561,7 @@ def clean_dict(type_dict: dict | list | str) -> dict | list | str:
     type_name = type_dict.get("type")
 
     if type_name is None:
-        type_name = "null"
+        return "null"
 
     if isinstance(type_name, str):
         recap_type_class = TYPE_CLASSES.get(type_name, ProxyType)

--- a/recap/types.py
+++ b/recap/types.py
@@ -336,8 +336,6 @@ def from_dict(
         type_dict = {"type": "union", "types": type_dict}
     elif isinstance(type_dict, str):
         type_dict = {"type": type_dict}
-    elif type_dict is None:
-        type_dict = {"type": "null"}
 
     # Create a copy to avoid modifying the input dictionary
     type_dict = type_dict.copy()
@@ -357,8 +355,6 @@ def from_dict(
                 union_types.append(from_dict(t, registry))
             elif isinstance(t, str):
                 union_types.append(from_dict({"type": t}, registry))
-            elif t is None:
-                union_types.append(from_dict({"type": "null"}, registry))
         recap_type = UnionType(union_types, **type_dict)
     elif isinstance(type_name, str):
         match type_name:
@@ -552,10 +548,6 @@ def clean_dict(type_dict: dict | list | str) -> dict | list | str:
     elif isinstance(type_dict, str):
         type_dict = {
             "type": type_dict,
-        }
-    elif type_dict is None:
-        type_dict = {
-            "type": "null",
         }
 
     type_name = type_dict.get("type")

--- a/recap/types.py
+++ b/recap/types.py
@@ -336,6 +336,8 @@ def from_dict(
         type_dict = {"type": "union", "types": type_dict}
     elif isinstance(type_dict, str):
         type_dict = {"type": type_dict}
+    elif type_dict is None:
+        type_dict = {"type": "null"}
 
     # Create a copy to avoid modifying the input dictionary
     type_dict = type_dict.copy()
@@ -355,6 +357,8 @@ def from_dict(
                 union_types.append(from_dict(t, registry))
             elif isinstance(t, str):
                 union_types.append(from_dict({"type": t}, registry))
+            elif t is None:
+                union_types.append(from_dict({"type": "null"}, registry))
         recap_type = UnionType(union_types, **type_dict)
     elif isinstance(type_name, str):
         match type_name:
@@ -548,6 +552,10 @@ def clean_dict(type_dict: dict | list | str) -> dict | list | str:
     elif isinstance(type_dict, str):
         type_dict = {
             "type": type_dict,
+        }
+    elif type_dict is None:
+        type_dict = {
+            "type": "null",
         }
 
     type_name = type_dict.get("type")


### PR DESCRIPTION
This code change will allow `null` values to be used without be surrounded by quotation marks, i.e. `"null"`.

Before this change, `type: null` was not acceptable but `type: "null"` was. With these changes, both `null` and `"null"` will be acceptable syntax. This change will also cover null values inside of `union` types.

Acceptable ✅ 
```yaml
type: union
types:
  - type: null
  - type: bool
```