### PR TITLE
Exclude `doc` and `default` from aliased types

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -319,6 +319,10 @@ class RecapTypeRegistry:
         # Registry contains types without aliases so aliased types don't get
         # accidentally redefined when referenced.
         recap_type.alias = None
+        # Do not include doc in aliases
+        recap_type.doc = None
+        # Do not include default in aliases
+        recap_type.extra_attrs.pop("default", None)
         self._type_registry[alias] = recap_type
 
     def from_alias(self, alias: str) -> RecapType:


### PR DESCRIPTION
Aliases currently include `doc` and `default` attributes when referenced.

```python
type: struct
fields:
  - name: foo
    alias: build.recap.Foo
    type: string
    default: some_default_string
  - name: bar
    type: build.recap.Foo
```

In this example, `bar` will also have a default of "some_default_string". This is not intuitive. This patch removes `doc` and `default` attributes when persisting alias types to the `RecapTypeRegistry`. Consequently, `bar` will no longer have a default. Explicit defaults in alias references will continue to work as expected:

```python
type: struct
fields:
  - name: foo
    alias: build.recap.Foo
    type: string
  - name: bar
    type: build.recap.Foo
    default: some_other_default
```

`bar` will have "some_other_default" as its default, regardless of what default is set (or not) for `foo`.

Closes #337