### PR TITLE
Add UUID to Postgres recognized types

### DIFF
--- a/recap/readers/postgresql.py
+++ b/recap/readers/postgresql.py
@@ -35,7 +35,9 @@ class PostgresqlReader(DbapiReader):
             base_type = StringType(bytes_=octet_length, variable=False)
         elif data_type == "uuid":
             base_type = StringType(
-                logical="build.recap.UUID", bytes_=36, variable=False
+                logical="build.recap.UUID",
+                bytes_=36,
+                variable=False,
             )
         elif data_type == "bytea" or data_type.startswith("bit varying"):
             base_type = BytesType(bytes_=MAX_FIELD_SIZE, variable=True)

--- a/recap/readers/postgresql.py
+++ b/recap/readers/postgresql.py
@@ -33,6 +33,10 @@ class PostgresqlReader(DbapiReader):
             base_type = StringType(bytes_=octet_length, variable=True)
         elif data_type.startswith("char"):
             base_type = StringType(bytes_=octet_length, variable=False)
+        elif data_type == "uuid":
+            base_type = StringType(
+                logical="build.recap.UUID", bytes_=36, variable=False
+            )
         elif data_type == "bytea" or data_type.startswith("bit varying"):
             base_type = BytesType(bytes_=MAX_FIELD_SIZE, variable=True)
         elif data_type.startswith("bit"):


### PR DESCRIPTION
UUID is a very common type for columns in PostgreSQL ([docs](https://www.postgresql.org/docs/current/datatype-uuid.html)). We therefore want to support this type in the recap PostgreSQL reader.