### PR TITLE
Add better error message for missing 'type' property

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -539,7 +539,10 @@ def clean_dict(type_dict: dict | list | str) -> dict | list | str:
     :param type_dict: A type dictionary, list, or string.
     :return: A cleaner, more compact type dictionary, list, or string.
     """
-
+    if isinstance(type_dict, dict) and "type" not in type_dict:
+        raise ValueError(
+            "'type' is a required field and was not found in the dictionary."
+        )
     if isinstance(type_dict, list):
         type_dict = {
             "type": "union",


### PR DESCRIPTION
We want to raise a `ValueError` with a helpful message when there is a missing `type` property. We have run into this situation many times already and we want to make it easier to debug.