### PR TITLE
Add `validate` methods for each RecapType

### DIFF
--- a/recap/types.py
+++ b/recap/types.py
@@ -101,6 +101,10 @@ class IntType(RecapType):
             other.signed,
         )
 
+    def validate(self) -> None:
+        if self.bits < 1 or self.bits > 2_147_483_647:
+            raise ValueError("bits must be between 1 and 2,147,483,647")
+
 
 class FloatType(RecapType):
     """Represents a floating point Recap type."""
@@ -111,6 +115,10 @@ class FloatType(RecapType):
 
     def __eq__(self, other):
         return super().__eq__(other) and self.bits == other.bits
+
+    def validate(self) -> None:
+        if self.bits < 1 or self.bits > 2_147_483_647:
+            raise ValueError("bits must be between 1 and 2,147,483,647")
 
 
 class StringType(RecapType):
@@ -127,6 +135,10 @@ class StringType(RecapType):
             other.variable,
         )
 
+    def validate(self) -> None:
+        if self.bytes_ < 1 or self.bytes_ > 9_223_372_036_854_775_807:
+            raise ValueError("bytes must be between 1 and 9,223,372,036,854,775,807")
+
 
 class BytesType(RecapType):
     """Represents a bytes Recap type."""
@@ -141,6 +153,10 @@ class BytesType(RecapType):
             other.bytes_,
             other.variable,
         )
+
+    def validate(self) -> None:
+        if self.bytes_ < 1 or self.bytes_ > 9_223_372_036_854_775_807:
+            raise ValueError("bytes must be between 1 and 9,223,372,036,854,775,807")
 
 
 class ListType(RecapType):
@@ -172,6 +188,7 @@ class ListType(RecapType):
             raise ValueError(
                 "List length must be between 0 and 9,223,372,036,854,775,807"
             )
+        self.values.validate()
 
 
 class MapType(RecapType):
@@ -188,6 +205,10 @@ class MapType(RecapType):
             other.values,
         )
 
+    def validate(self) -> None:
+        self.keys.validate()
+        self.values.validate()
+
 
 class StructType(RecapType):
     """Represents a struct Recap type."""
@@ -198,6 +219,10 @@ class StructType(RecapType):
 
     def __eq__(self, other):
         return super().__eq__(other) and self.fields == other.fields
+
+    def validate(self) -> None:
+        for field in self.fields:
+            field.validate()
 
 
 class EnumType(RecapType):

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -1522,3 +1522,73 @@ def test_alias_regex(test_input, expected):
 def test_register_alias(recap_type):
     registry = RecapTypeRegistry()
     registry.register_alias(recap_type)
+
+
+def test_int_type_validate():
+    invalid_int1 = IntType(-1)
+    invalid_int2 = IntType(2_147_483_648)
+
+    with pytest.raises(ValueError):
+        invalid_int1.validate()
+    with pytest.raises(ValueError):
+        invalid_int2.validate()
+
+
+def test_float_type_validate():
+    invalid_float1 = FloatType(-1)
+    invalid_float2 = FloatType(2_147_483_648)
+
+    with pytest.raises(ValueError):
+        invalid_float1.validate()
+    with pytest.raises(ValueError):
+        invalid_float2.validate()
+
+
+def test_string_type_validate():
+    invalid_string1 = StringType(-1)
+    invalid_string2 = StringType(9_223_372_036_854_775_808)
+
+    with pytest.raises(ValueError):
+        invalid_string1.validate()
+    with pytest.raises(ValueError):
+        invalid_string2.validate()
+
+
+def test_bytes_type_validate():
+    invalid_bytes1 = BytesType(-1)
+    invalid_bytes2 = BytesType(9_223_372_036_854_775_808)
+
+    with pytest.raises(ValueError):
+        invalid_bytes1.validate()
+    with pytest.raises(ValueError):
+        invalid_bytes2.validate()
+
+
+def test_list_type_validate():
+    invalid_list1 = ListType(StringType(65_536), length=-1)
+    invalid_list2 = ListType(StringType(65_536), variable=False)
+    invalid_list3 = ListType(StringType(), length=9_223_372_036_854_775_808)
+
+    with pytest.raises(ValueError):
+        invalid_list1.validate()
+    with pytest.raises(ValueError):
+        invalid_list2.validate()
+    with pytest.raises(ValueError):
+        invalid_list3.validate()
+
+
+def test_map_type_validate():
+    invalid_map_keys = MapType(StringType(9_223_372_036_854_775_808), IntType(32))
+    invalid_map_values = MapType(StringType(65_536), IntType(2_147_483_648))
+
+    with pytest.raises(ValueError):
+        invalid_map_keys.validate()
+    with pytest.raises(ValueError):
+        invalid_map_values.validate()
+
+
+def test_struct_type_validate():
+    invalid_struct = StructType([StringType(65_536), IntType(2_147_483_648)])
+
+    with pytest.raises(ValueError):
+        invalid_struct.validate()


### PR DESCRIPTION
I've added validation rules to each RecapType that needs to be validated. The rules are all according to the [0.2.0](https://recap.build/specs/type) spec. These rules are run when `from_dict` is called.

Closes #362