### PR TITLE
Add `format: bytes` support for JSONSchemaConverter.to_recap

### DIFF
--- a/recap/converters/json_schema.py
+++ b/recap/converters/json_schema.py
@@ -78,6 +78,11 @@ class JSONSchemaConverter:
             case {"type": "array", "items": items}:
                 values = self._parse(items, alias_strategy)
                 return ListType(values, **extra_attrs)
+            case {"type": "string", "format": "bytes"}:
+                return BytesType(
+                    bytes_=9_223_372_036_854_775_807,
+                    **extra_attrs,
+                )
             case {"type": "string", "format": "date"}:
                 return StringType(
                     bytes_=9_223_372_036_854_775_807,

--- a/tests/unit/converters/test_json_schema.py
+++ b/tests/unit/converters/test_json_schema.py
@@ -237,6 +237,30 @@ def test_default_attribute():
     ]
 
 
+def test_convert_bytes():
+    schema = """
+    {
+        "type": "object",
+        "properties": {
+            "img": {
+                "type": "string",
+                "format": "bytes"
+            }
+        }
+    }
+    """
+    result = JSONSchemaConverter().to_recap(schema)
+    assert result == StructType(
+        [
+            UnionType(
+                [NullType(), BytesType(bytes_=9_223_372_036_854_775_807)],
+                name="img",
+                default=None,
+            ),
+        ]
+    )
+
+
 def test_convert_date():
     converter = JSONSchemaConverter()
     schema = """


### PR DESCRIPTION
The `JSONSchemaConverter` now converts string types to `BytesType` if `"format": "bytes"` is set for the JSON schema string type.

BytesTypes are created with a LONG_MAX length because JSON schema imposes no max.

Closes #345