### PR TITLE
Link README.md to recap.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,15 @@ Recap is a Python library that reads and writes schemas from web services, datab
 
 | Format      | Read | Write |
 | ----------- | ----------- | ----------- |
-| [Avro](https://avro.apache.org) | ✅ | ✅ |
-| [Protobuf](https://protobuf.dev) | ✅ | ✅ |
-| [JSON Schema](https://json-schema.org) | ✅ |  |
-| [Snowflake](https://www.snowflake.com) | ✅ |  |
-| [PostgreSQL](https://www.postgresql.org) | ✅ |  |
-| [BigQuery](https://cloud.google.com/bigquery) | ✅ |  |
-| [Confluent Schema Registry](https://github.com/confluentinc/schema-registry) | ✅ |  |
-| [Hive Metastore](https://cwiki.apache.org/confluence/display/hive/design#Design-Metastore) | ✅ |  |
+| [Avro](https://recap.build/docs/converters/avro/) | ✅ | ✅ |
+| [Protobuf](https://recap.build/docs/converters/protobuf/) | ✅ | ✅ |
+| [JSON Schema](https://recap.build/docs/converters/json-schema/) | ✅ |  |
+| [Snowflake](https://recap.build/docs/readers/snowflake/) | ✅ |  |
+| [PostgreSQL](https://recap.build/docs/readers/postgresql/) | ✅ |  |
+| [MySQL](https://recap.build/docs/readers/mysql/) | ✅ |  |
+| [BigQuery](https://recap.build/docs/readers/bigquery/) | ✅ |  |
+| [Confluent Schema Registry](https://recap.build/docs/readers/confluent-schema-registry/) | ✅ |  |
+| [Hive Metastore](https://recap.build/docs/readers/hive-metastore/) | ✅ |  |
 
 ## Supported Types
 


### PR DESCRIPTION
The format table was linking to serde/system pages. It should link to recap.build for SEO.